### PR TITLE
Correct break when calculating end time on DST changeover (Issue #22)

### DIFF
--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -97,6 +97,7 @@ None known.
 
 use strict;
 use utf8;
+use XMLTV::Version '$Id$';
 use DateTime;
 use Encode; # used to convert 'perl strings' into 'utf-8 strings'
 use XML::LibXML;
@@ -124,7 +125,7 @@ my( $opt, $conf ) = ParseOptions( {
     capabilities => [qw/apiconfig baseline manualconfig preferredmethod/],
     listchannels_sub => \&list_channels,
     stage_sub => \&config_stage,
-    version => '$Id: $grabber_name,v $grabber_version 2017/12/17 09:30:00 nsenica Exp $',
+    version => '$Id$',
     description => "Portugal (Vodafone)",
     preferredmethod => 'allatonce',
     defaults => { days => $maxdays, offset => 0, quiet => 0, debug => 0 },
@@ -269,7 +270,7 @@ sub get_epg
                 $prog{title} = [ [ parse_title(\%prog, sanitizeUTF8($programme->{programTitle})), 'pt' ] ];
                 $prog{desc} = [ [ sanitizeUTF8($programme->{programDetails}), 'pt' ] ];
 
-                my ($dtstart, $dtend) = make_dates($programme->{date}, $programme->{startTime}, $programme->{endTime});
+                my ($dtstart, $dtend) = make_dates($programme->{date}, $programme->{startTime}, $programme->{endTime}, $programme->{duration});
 
                 $prog{start} = $dtstart;
                 $prog{stop} = $dtend;
@@ -335,7 +336,7 @@ sub json_request {
 
 sub make_dates
 {
-    my( $date, $startTime, $endTime ) = @_;
+    my( $date, $startTime, $endTime, $duration ) = @_;
 
     my($day, $month, $year) =
         ($date =~ m/(\d{2})-(\d{2})-(\d{4})/);
@@ -352,18 +353,7 @@ sub make_dates
                             time_zone => 'Europe/Lisbon',
     );
 
-    my $dtend = DateTime->new( year   => $year,
-                            month  => $month,
-                            day    => $day,
-                            hour   => $endHour,
-                            minute => $endMinute,
-                            second => 0,
-                            time_zone => 'Europe/Lisbon',
-    );
-
-    if ($dtend < $dtstart) {
-        $dtend->add(days => 1);
-    }
+    my $dtend = $dtstart->clone()->add(minutes => $duration);
 
     return ($dtstart->strftime( '%Y%m%d%H%M%S %z' ), $dtend->strftime( '%Y%m%d%H%M%S %z' ));
 }


### PR DESCRIPTION
Fix 
`Invalid local time for date in time zone: Europe/Lisbon`
when creating programme end times around DST switch
