### PR TITLE
Fixes issue #28 related to matching 'Rating'

### DIFF
--- a/grab/uk_tvguide/tv_grab_uk_tvguide
+++ b/grab/uk_tvguide/tv_grab_uk_tvguide
@@ -600,7 +600,7 @@ sub fetch_listings {
 
 							# rating
 							#		<span class="programmetext">Rating<br></span><span class="programmeheading">3.9</span>
-							my $showrating = $show->look_down('_tag' => 'span', 'class' => 'programmetext', sub { $_[0]->as_text =~ /Rating/ } );
+							my $showrating = $show->look_down('_tag' => 'span', 'class' => 'programmetext', sub { $_[0]->as_trimmed_text =~ /^Rating$/ } );
 							if ($showrating) {
 								$showrating = $showrating->right;
 								$showrating = $showrating->right if ($showrating->tag eq 'br');


### PR DESCRIPTION
This fixes the error 'Can't call method "tag" on an undefined value at /usr/bin/tv_grab_uk_tvguide line 606.' when 'Rating' is matched incorrectly due to it also appearing in the programme description and then causing a match further down the HTML tree.

https://github.com/XMLTV/xmltv/issues/28