### PR TITLE
Disable broken countries (SF#517)

### DIFF
--- a/grab/huro/tv_grab_huro.in
+++ b/grab/huro/tv_grab_huro.in
@@ -195,10 +195,11 @@ my ($opt_days, $opt_offset, $opt_help, $opt_output,
 our $FETCHOFFSET = 0;
 our ($DAYSPERPAGE, $TZ, $COUNTRY, $CONFIG_FILE, $WNAME, $WSTIME);
 our (%CATMAP, %JOBMAP, %CHANNELS, %WTIMES);
-our %COUNTRIES = (Hungary => [ 'hu', '+0100' ],
-                  Czech   => [ 'cz', '+0100' ],
-                  Romania => [ 'ro', '+0200' ],
-                 Slovakia => [ 'sk', '+0100' ]);
+#our %COUNTRIES = (Hungary => [ 'hu', '+0100' ],
+#                  Czech   => [ 'cz', '+0100' ],
+#                  Romania => [ 'ro', '+0200' ],
+#                 Slovakia => [ 'sk', '+0100' ]);
+our %COUNTRIES = (Hungary => [ 'hu', '+0100' ]);
 our %WORDS = (
 		cz => { episode => "Epizoda",
 				minute  =>  "minut",


### PR DESCRIPTION
tv_grab_huro no longer works for CZ, RO, SK. It's confusing to display them in the configuration dialogues, so they've been removed.
https://sourceforge.net/p/xmltv/bugs/517/