### PR TITLE
tv_grab_na_dtv: fix channel sorting

### DIFF
--- a/grab/na_dtv/tv_grab_na_dtv
+++ b/grab/na_dtv/tv_grab_na_dtv
@@ -358,7 +358,7 @@ sub read_queue {
 }
 
 # For sorting %ch by its (channel number) key:
-sub numerically { $a cmp $b }
+sub numerically { $a <=> $b }
 
 # This is what the main process does first.  Variables in here will
 # go nicely out of scope before the child processes are started.


### PR DESCRIPTION
What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
No.

Please explain what this PR does
--------------------------------
Prior to this fix `tv_grab_na_dtv --configure` sorted channels ASCII-betically:
```
1 Infomercial Channel (1) [yes,no,all,none (default=no)] none
100 Seasonal Sport Offer Channel no
101 AUDIENCE HD no
...
148 DTV Cinema 148 HD no
149 DTV Cinema 149 HD no
15 Parkersburg, WV WTAP NBC 15 A3 HD no
150 DTV Cinema 150 HD no
151 DTV Cinema 151 HD no
...
168 DTV Cinema 168 no
169 DTV Cinema 169 no
17 Parkersburg, WV WTAPDT2 MNT 17 A3 SD no
170 DTV Cinema 170 no
171 DTV Cinema 171 no
...
199 Kids Mix Channel no
202 CNN HD no
2020 MediaSet Italia no
2021 Rai Italia no
...
```
After the fix they are sorted numerically:
```
1 Infomercial Channel (1) [yes,no,all,none (default=no)] none
6 Parkersburg WSYX ABC 6 A3 HD (Virt) no
15 Parkersburg, WV WTAP NBC 15 A3 HD no
17 Parkersburg, WV WTAPDT2 MNT 17 A3 SD no
...
98 Interactive Advertising Channel HD (98) no
99 XTRA (99) no
100 Seasonal Sport Offer Channel no
101 AUDIENCE HD no
...
179 DTV Cinema 179 no
199 Kids Mix Channel no
202 CNN HD no
203 LOOK Network 203 no
...
```

Any other information?
----------------------
This was broken by commit 4e0cdbe0c9cdbf8fa5bd5382f79ae51bda9fa65e.

Where have you tested these changes?
------------------------------------
**Operating System:** Linux (Ubuntu 19.10)

**Perl Version:** v5.28.1
