### PR TITLE
Correct tv_grab_zz_sdjson to be XMLTV DTD compliant

### DIFF
--- a/grab/zz_sdjson/tv_grab_zz_sdjson
+++ b/grab/zz_sdjson/tv_grab_zz_sdjson
@@ -1327,10 +1327,12 @@ sub get_program_audio {
 }
 
 # The xmltv docs state this field is "When and where the programme was last shown".
-# However mythtv expects the original air date to be in this field.
+# Programs that are marked as new by Schedules Direct can not have a XMLTV previously_shown.
 sub get_program_previously_shown {
-	my ($details) = @_;
+	my ($program, $details) = @_;
 	my %previously_shown;
+
+	return undef if(get_program_new($program));
 
 	my $date = $details->{'originalAirDate'};
 	if($date) {
@@ -1447,10 +1449,10 @@ sub write_programme {
 			'episode-num'      => get_program_episode($program, $details),
 			'video'            => get_program_video($program),
 			'audio'            => get_program_audio($program),
-			'previously-shown' => get_program_previously_shown($details),
+			'previously-shown' => get_program_previously_shown($program, $details),
 			'premiere'         => get_program_premiere($program),
 #			'last-chance'      => undef,
-			'new'              => get_program_new($program),
+#			'new'              => undef,
 			'subtitles'        => get_program_subtitles($program),
 			'rating'           => get_program_rating($program, $details),
 			'star-rating'      => get_program_star_rating($details),


### PR DESCRIPTION
Per discussions on the xmltv-devel list (starting
on 2020-04-13, subject "Request for clarification"),
it was agreed by the project elders that new episodes
of programs cannot have a previously shown, and
that new is only for true first showings of the
first episode (the Schedules Direct definition of
new, which is every new episode of every series
is not the same as the XMLTV definition of new).

The tv_grab_zz_sdjson grabber is not XMLTV compliant.

Note that the (deleted in this patch) comment about
MythTV requiring the original airdate is no longer
applicable in the latest MythTV release (i.e. it
adjusts the data per XMLTV definitions as necessary).

Closes: #91
