### PR TITLE
Fix "Use of uninitialized value $zip in string at ... line 316"

### DIFF
--- a/grab/na_dtv/tv_grab_na_dtv
+++ b/grab/na_dtv/tv_grab_na_dtv
@@ -555,7 +555,7 @@ sub list_channels {
 
   $VERBOSE = !$opt->{quiet};
 
-  my $browser = getBrowser($conf);
+  my $browser = getBrowser($opt, $conf);
   &scrape_channel_list( $browser, $conf->{zip}[0], $conf->{channel}, \%ch );
 
   my $xml = $XML_PRELUDE;


### PR DESCRIPTION
commit 66b677fc changed the params for the getBrowser routine
but did not update all uses, resulting in incorrect results.

Fixes: #103
