### PR TITLE
update version for cherry-pick typo correction

### DIFF
--- a/grab/zz_sdjson_sqlite/tv_grab_zz_sdjson_sqlite
+++ b/grab/zz_sdjson_sqlite/tv_grab_zz_sdjson_sqlite
@@ -44,6 +44,7 @@
 #
 # Version history:
 #
+# 2020/09/15 - 1.102 - update for cherry-pick typo correction
 # 2020/06/21 - 1.101 - rename scaledownload to scale-download
 # 2020/06/20 - 1.100 - add support for --scaledownload
 # 2020/06/12 - 1.99 - include programID in metadata
@@ -193,7 +194,7 @@ use sort 'stable';
 my $RFC2838_COMPLIANT          = 1;            # RFC2838 compliant station ids, which makes XMLTV
                                                # validate even though the docs say "SHOULD" not "MUST"
 
-my $SCRIPT_VERSION             = '$Id: tv_grab_zz_sdjson_sqlite,v 1.101 2020/06/21 20:30:00 gtb Exp ed $';
+my $SCRIPT_VERSION             = '$Id: tv_grab_zz_sdjson_sqlite,v 1.102 2020/09/15 21:30:00 gtb Exp ed $';
 my $SCRIPT_URL                 = 'https://github.com/garybuhrmaster/tv_grab_zz_sdjson_sqlite';
 my $SCRIPT_NAME                = basename("$0");
 my $SCRIPT_NAME_DIR            = dirname("$0");


### PR DESCRIPTION
Pull request to update tv_grab_zz_sdjson_sqlite to upstream's commit to bump version after the cherry pick of the typo correction in 0996952a3792c2ec981262dbfa0382548f1c4924