### PR TITLE
tv_grab_uk_tvguide: fix for missing form options in channel listings

### DIFF
--- a/grab/uk_tvguide/tv_grab_uk_tvguide
+++ b/grab/uk_tvguide/tv_grab_uk_tvguide
@@ -206,6 +206,13 @@ sub fetch_listings {
 				if ($tree) {
 					my $channelname = $tree->look_down('_tag' => 'option', 'value' => $channel_id);
 
+					# Try a fallback method if the form options are missing
+					if (!defined $channelname) {
+						my $fallback = $tree->look_down('_tag' => 'input', 'name' => 'cTime');
+						$fallback = $fallback->look_up('_tag', 'tr') if $fallback;
+						$channelname = $fallback->look_down('_tag' => 'span', 'class' => 'programmeheading') if $fallback;
+					}
+
 					# tvguide website can be very slow - try to avoid barfing when no response
 					if (!defined $channelname) {
 						warning "Unable to retrieve web page for $channel_id";


### PR DESCRIPTION
What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
No.

Please explain what this PR does
--------------------------------
So, for a long time, I've been running `tv_grab_uk_tvguide` in a loop (with up to 5 retries and a sleep between of 1 hour) if it doesn't exit with 0.  The problem is the tvguide.co.uk website is pretty flaky (the UX sucks too, but that's by the by) and often I end up with a few log entries of `Unable to retrieve web page for $channel_id` which causes retries and sometimes a total failure if the max retries is exceeded, which means manual intervention.  I've been meaning to look at this for a long time now, but have only just got around to it.

The problem is that - for whatever reason - the tvguide.co.uk website does not always insert the options into the form that is searched to find `$channelname` - see the attached channel listing HTML page for an example of this.  Having got around to understanding the problem, I now realise my retry solution has not been a very good one, due to the transparent caching also coming into play.

This PR modifies the grabber to obtain the channel name from the second occurrence of:

`<span class=programmeheading>`

It has been working pretty well for me over the last 5 days:
```
2020-12-03-05:37: finished on try: 1
2020-12-03-17:37: finished on try: 1
2020-12-04-05:37: finished on try: 1
2020-12-04-17:37: finished on try: 1
2020-12-05-05:37: finished on try: 2
2020-12-05-17:49: finished on try: 1
2020-12-06-05:37: finished on try: 1
2020-12-06-17:37: finished on try: 1
2020-12-07-05:37: finished on try: 1
2020-12-07-17:37: finished on try: 1
```
Note: I had to manually kill the `tv_grab_uk_tvguide` process that started on 2020-12-05-05:37, as it hung on the first try at 05:39 for no obvious reason (CPU usage 0%, memory usage 2.2% (~22MB), plenty of disk space).  That is something I have very occassionally seen before.  Perhaps it's a network issue where something in LWP or called by LWP never returns and doesn't time out?  There was nothing in the error log that was out of place - using `grep -v ^Fetching` on it returned nothing.  Annoyingly, by the time I killed the hung first try, the second try didn't quite finish before the scheduled evening run at 17:37, so that had to be manually run a little later.

Any other information?
----------------------
[121.html.txt](https://github.com/XMLTV/xmltv/files/5654862/121.html.txt)

Where have you tested these changes?
------------------------------------
**Operating System:** Debian 9

**Perl Version:** v5.24.1
