### PR TITLE
Adds description for icon element in channel field

### DIFF
--- a/xmltv.dtd
+++ b/xmltv.dtd
@@ -169,6 +169,15 @@ obscure names last.  The lang attribute follows RFC 1766.
 <!ELEMENT display-name (#PCDATA)>
 <!ATTLIST display-name lang CDATA #IMPLIED>
 
+<!-- A URL where you can find the channel icon. This can be used by users
+to display this logo in channel listings.
+
+Many icon elements can be specified, the first one should be the official
+one, and others can be used as fallback in case of error retrieval.
+-->
+<!ELEMENT icon>
+<!ATTLIST icon src CDATA #REQUIRED>
+
 <!-- A URL where you can find out more about the element that contains
 it (programme or channel).  This might be the official site, or a fan
 page, whatever you like really.


### PR DESCRIPTION
I'm currently working on a Rust crate to generate XMLTV TV listing files. (Available here)

To conform to the XMLTV specification, I'm using a lot the DTD available in your repository.

I've found that the icon field in the channel element misses a description, which can lead to bad interpretations... I'll link a PR to this issue to suggest a consistent description.

    XMLTV Version? 1.0.0 -> master branch

    What happened? Missing description field for icon attribute of channel
