### PR TITLE
foxtv: improvements

### DIFF
--- a/grab/fi/fi/source/foxtv.pm
+++ b/grab/fi/fi/source/foxtv.pm
@@ -92,6 +92,9 @@ sub grab {
 
             # Cleanup some of the most common inconsistencies....
             $episode_name =~ s/^$cleanup_match// if defined $episode_name;
+            # If cleanup leaves only numbers to episode name cleanup them
+            # Example if episode name is Jakso 8, cleanup removes Jakso but don't space and number
+            $episode_name =~ s/^(\s+\d{1,2})$// if defined $episode_name;
             if ($desc) {
               ($desc = $desc->as_text()) =~ s/^$cleanup_match//;
 

--- a/grab/fi/fi/source/foxtv.pm
+++ b/grab/fi/fi/source/foxtv.pm
@@ -96,7 +96,7 @@ sub grab {
               ($desc = $desc->as_text()) =~ s/^$cleanup_match//;
 
               # Title can be first in description too
-              $desc =~ s/^$title(?:\.\s+)?//;
+              $desc =~ s/^$title\.\s+?//;
 
               # Episode title can be first in description too
               $desc =~ s/^$episode_name(?:\.\s+)?// if defined $episode_name;

--- a/grab/fi/fi/source/foxtv.pm
+++ b/grab/fi/fi/source/foxtv.pm
@@ -42,8 +42,10 @@ sub grab {
   if ($root) {
 
     #
-    # Each page contains the programmes from current day to requested day.
+    # Each page contains the programmes from previous day to next day from requested day.
+    # Sometimes page doesn't have programmes older than ~4 hours
     # All program info is contained within a section with class "row day"
+    # Each row day section starts at 06.00 and ends 05.59 next day
     #
     #  <div id="scheduleContainer">
     #   <section class="row day" data-magellan-destination="day20160514" ...>
@@ -65,61 +67,72 @@ sub grab {
     #  </div>
     #
     my $opaque = startProgrammeList($id, "fi");
-    if (my $container = $root->look_down("class"                     => "row day",
-					 "data-magellan-destination" => "day$today")) {
-      if (my @programmes = $container->look_down("_tag"  => "li",
-						 "class" => qr/acilia-schedule-event/)) {
-	foreach my $programme (@programmes) {
-	  my $start = $programme->find("h5");
-	  my $title = $programme->find("h3");
+    if (my $container = $root->look_down("_tag" => "div",
+                                         "id" => "scheduleContainer")) {
+      my @programmes_today = $root->look_down("_tag"  => "li",
+                                              "class" => qr/acilia-schedule-event/,
+                                              "data-datetime-date" => $today->ymdd());
+      my $first_tomorrow = $root->look_down("_tag"  => "li",
+                                            "class" => qr/acilia-schedule-event/,
+                                            "data-datetime-date" => $tomorrow->ymdd());
+      foreach my $programme (@programmes_today) {
+        my $start = $programme->find("h5");
+        my $title = $programme->find("h3");
 
-	  if ($start && $title) {
-	    if (my($hour, $minute) =
-		$start->as_text() =~ /^(\d{2})[:.](\d{2})$/) {
-	      my $desc  = $programme->find("p");
-	      my $extra = $programme->find("h4");
+        if ($start && $title) {
+          if (my($hour, $minute) = $start->as_text() =~ /^(\d{2})[:.](\d{2})$/) {
+            my $desc  = $programme->find("p");
+            my $extra = $programme->find("h4");
 
-	      $title = $title->as_text();
+            $title = $title->as_text();
 
-	      my($episode_name, $season, $episode_number) =
-		$extra->as_text() =~ /^(.*)?,\s+Kausi\s+(\d+)\s+\S\s+Jakso\s+(\d+)\s*$/
-		  if $extra;
+            my($episode_name, $season, $episode_number) =
+               $extra->as_text() =~ /^(.*)?,\s+Kausi\s+(\d+)\s+\S\s+Jakso\s+(\d+)\s*$/
+                 if $extra;
 
-	      # Cleanup some of the most common inconsistencies....
-	      $episode_name =~ s/^$cleanup_match// if defined $episode_name;
-	      if ($desc) {
-	        ($desc = $desc->as_text()) =~ s/^$cleanup_match//;
+            # Cleanup some of the most common inconsistencies....
+            $episode_name =~ s/^$cleanup_match// if defined $episode_name;
+            if ($desc) {
+              ($desc = $desc->as_text()) =~ s/^$cleanup_match//;
 
-		# Title can be first in description too
-		$desc =~ s/^$title(?:\.\s+)?//;
+              # Title can be first in description too
+              $desc =~ s/^$title(?:\.\s+)?//;
 
-		# Episode title can be first in description too
-		$desc =~ s/^$episode_name(?:\.\s+)?// if defined $episode_name;
+              # Episode title can be first in description too
+              $desc =~ s/^$episode_name(?:\.\s+)?// if defined $episode_name;
 
-		# Description can be empty
-		undef $desc if $desc eq '';
-	      }
+              # Description can be empty
+              undef $desc if $desc eq '';
+            }
 
-	      # Episode name can be the same as the title
-	      undef $episode_name
-		if defined($episode_name) &&
-		   (($episode_name eq '') || ($episode_name eq $title));
+            # Episode name can be the same as the title
+            undef $episode_name
+              if defined($episode_name) &&
+                 (($episode_name eq '') || ($episode_name eq $title));
 
-	      debug(3, "List entry fox ($hour:$minute) $title");
-	      debug(4, $episode_name) if defined $episode_name;
-	      debug(4, $desc)         if defined $desc;
-	      debug(4, sprintf("s%02de%02d", $season, $episode_number))
-		if (defined($season) && defined($episode_number));
+            debug(3, "List entry fox ($hour:$minute) $title");
+            debug(4, $episode_name) if defined $episode_name;
+            debug(4, $desc)         if defined $desc;
+            debug(4, sprintf("s%02de%02d", $season, $episode_number))
+              if (defined($season) && defined($episode_number));
 
-	      my $object = appendProgramme($opaque, $hour, $minute, $title);
-	      $object->description($desc);
-	      $object->episode($episode_name, "fi");
-	      $object->season($season);
-	      $object->episode_number($episode_number);
-	    }
-	  }
-	}
+            my $object = appendProgramme($opaque, $hour, $minute, $title);
+            $object->description($desc);
+            $object->episode($episode_name, "fi");
+            $object->season($season);
+            $object->episode_number($episode_number);
+          }
+        }
       }
+
+      # Get stop time for last entry in the table: first start
+      if ($first_tomorrow) {
+        my $start = $first_tomorrow->find("h5");
+        if (my($hour, $minute) = $start->as_text() =~ /^(\d{2})[:.](\d{2})$/) {
+          appendProgramme($opaque, $hour, $minute, "DUMMY");
+        }
+      }
+
     }
 
     # Done with the HTML tree
@@ -129,6 +142,10 @@ sub grab {
     #
     # First entry always starts on $today -> don't use $yesterday
     # Last entry always ends on $tomorrow.
+    #
+    # Unfortunately we don't have a stop time for the last entry. We fix this
+    # (see above) by adding the start time of the first entry from tomorrow
+    # as a DUMMY program.
     return(convertProgrammeList($opaque, undef, $today, $tomorrow));
   }
 


### PR DESCRIPTION
What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
(If yes, please provide the issue number)
…

Please explain what this PR does
--------------------------------
I changed method how requested days events are grabbed to use li class "acilia-schedule-event" and "data-datetime-date" instead of section class "row day" which only contains data from 06.00 - 05.59 next day.

I also added first program from tomorrow as dummy.  That way we get an end time to requested days last program. I found this fix from foxtv.pm Github history.

Edit. Two new changes:
1. I make changes to how title is removed from description if it is same. Previously it removed part of description if program name was mentioned in it. Example: program name: Kymppitonni and description: Kymppitonnin voitosta kilpailemassa... It previously removed "Kymppitonni" from description so description was "n voitosta kilpailemassa...".

2. Episode name cleanup left episode number because it doesn't have dot at end. Example "Jakso 8" it removed Jakso but not " 08".

Any other information?
----------------------
(For example, has this change been discussed on the xmltv-devel mailing list?)
…

Where have you tested these changes?
------------------------------------
**Operating System:** Ubuntu

**Perl Version:** …
