### PR TITLE
Support Schedules Direct redirection response

### DIFF
--- a/grab/zz_sdjson/tv_grab_zz_sdjson
+++ b/grab/zz_sdjson/tv_grab_zz_sdjson
@@ -100,6 +100,7 @@ my $sd_json_request_max = 5000;
 
 my $ua = LWP::UserAgent->new(agent => "$grabber_name $grabber_version");
 $ua->default_header('accept-encoding' => scalar HTTP::Message::decodable());
+$ua->requests_redirectable(['GET', 'HEAD', 'POST', 'PUT', 'DELETE']);
 
 my $debug;
 my $quiet;


### PR DESCRIPTION
The new Schedules Direct JSON endpoint may issue a
redirect to a S3 bucket.  Allow LWP to follow redirects
for additional methods.

Thanks for taking the time to open a Pull Request (PR). Please take a moment to review our open/closed PRs above, in case a similar contribution has already been offered.

If you are opening a new Pull Request, please give it a descriptive title and fill out the blanks below, providing as much information as possible.

Pull Requests should be made against our master branch, and rebased if necessary.

What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [X] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
(If yes, please provide the issue number)
…

Please explain what this PR does
--------------------------------

This fixes a fetch issue with the new Schedules Direct JSON endpoint.

…

Any other information?
----------------------
(For example, has this change been discussed on the xmltv-devel mailing list?)
…

Where have you tested these changes?
------------------------------------
**Operating System:** …

Linux

**Perl Version:** …

5.34