### PR TITLE
Fix for Dockerfile smell DL4000

### DIFF
--- a/ci/Dockerfile.ubuntu-cosmic
+++ b/ci/Dockerfile.ubuntu-cosmic
@@ -2,7 +2,7 @@
 
 FROM ubuntu:cosmic
 
-MAINTAINER Nick Morrott <knowledgejunkie@gmail.com>
+LABEL maintainer="Nick Morrott <knowledgejunkie@gmail.com>" 
 
 ENV DEBIAN_FRONTEND 'noninteractive'
 ENV TZ 'Europe/London'


### PR DESCRIPTION
Thanks for taking the time to open a Pull Request (PR). Please take a moment to review our open/closed PRs above, in case a similar contribution has already been offered.

If you are opening a new Pull Request, please give it a descriptive title and fill out the blanks below, providing as much information as possible.

Pull Requests should be made against our master branch, and rebased if necessary.

What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
None

Please explain what this PR does
--------------------------------
Hi!
The Dockerfile placed at "ci/Dockerfile.ubuntu-cosmic" contains the best practice violation [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL4000 occurs when the deprecated MAINTAINER instruction is used.
In this pull request, we propose a fix for that smell generated by our fixing tool. We verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the MAINTAINER instruction is replaced by an equivalent LABEL instruction as recommended by the official guidelines.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.

Any other information?
----------------------
None

Where have you tested these changes?
------------------------------------
Only affects Dockerfile
