### PR TITLE
Fix #208: broken tv_grab_pt_meo

### DIFF
--- a/grab/Get_nice.pm
+++ b/grab/Get_nice.pm
@@ -34,7 +34,8 @@ package XMLTV::Get_nice;
 # 0.005067 : new method post_nice_json()
 # 0.005070 : skip get_nice sleep for cached pages
 # 0.005070 : support passing HTML::TreeBuilder options via a hashref
-our $VERSION = 0.005070;
+# 0.005071 : accept optional HTTP request headers in post_nice_json
+our $VERSION = 0.005071;
 
 use base 'Exporter';
 our @EXPORT = qw(get_nice get_nice_tree get_nice_xml get_nice_json post_nice_json error_msg);
@@ -191,10 +192,11 @@ sub get_nice_aux( $ ) {
 # Arguments:
 #    URI to post to
 #    JSON object with the AJAX data to be posted e.g. "{ 'programId':'123456', 'channel':'BBC'}"
+# Optional arguments:
+# i) hash with additional HTTP request headers to be posted
 #
-sub post_nice_json( $$ ) {
-    my $url = shift;
-    my $json = shift;
+sub post_nice_json ( $$;% ) {
+    my ($url, $json, %additional_headers) = @_;
 
     require JSON;
 
@@ -207,7 +209,12 @@ sub post_nice_json( $$ ) {
         sleep $sleep_time if $sleep_time > 0;
     }
 
-    my $r = $ua->post($url, 'Content_Type' => 'application/json; charset=utf-8', 'Content' => $json);
+    my %default_headers = (
+      'Content_Type' => 'application/json; charset=utf-8',
+    );
+    my %headers = (%default_headers, %additional_headers);
+
+    my $r = $ua->post($url, %headers, 'Content' => $json);
 
     $last_get_time = time();
 

--- a/grab/pt_meo/test.conf
+++ b/grab/pt_meo/test.conf
@@ -6,20 +6,22 @@ channel!100.meo.pt          		#  100 : RTP MEMÓRIA
 channel!101.meo.pt          		#  101 : Q HD
 channel!105.meo.pt          		#  105 : SIC RADICAL
 channel!106.meo.pt          		#  106 : MTV Portugal HD
-channel!107.meo.pt          		#  107 : BLAZE
-channel!108.meo.pt          		#  108 : FUEL TV
+channel!107.meo.pt          		#  107 : AMC Break
 channel!109.meo.pt          		#  109 : GAMETOON
 channel!11.meo.pt           		#   11 : Canal 11
 channel!110.meo.pt          		#  110 : ADVNCE
-channel!115.meo.pt          		#  115 : Crime + Investigation HD
-channel!116.meo.pt          		#  116 : CBS REALITY
+channel!114.meo.pt          		#  114 : AMC Crime
+channel!115.meo.pt          		#  115 : Investigation Discovery
 channel!118.meo.pt          		#  118 : TLC
 channel!119.meo.pt          		#  119 : GALERIA
 channel!12.meo.pt           		#   12 : TVI FICÇÃO
 channel!120.meo.pt          		#  120 : SIC CARAS
 channel!121.meo.pt          		#  121 : E! ENTERTAINMENT HD
-channel!123.meo.pt          		#  123 : 24 KITCHEN HD
+channel!122.meo.pt          		#  122 : Casa e Cozinha
+channel!123.meo.pt          		#  123 : 24 KITCHEN
+channel!124.meo.pt          		#  124 : Travelxp
 channel!126.meo.pt          		#  126 : FTV HD
+channel!127.meo.pt          		#  127 : Home & Garden TV
 channel!128.meo.pt          		#  128 : MÁS CHIC
 channel!129.meo.pt          		#  129 : S+
 channel!13.meo.pt           		#   13 : A BOLA TV
@@ -31,9 +33,9 @@ channel!134.meo.pt          		#  134 : MCM TOP HD
 channel!135.meo.pt          		#  135 : CLUBBING TV HD
 channel!136.meo.pt          		#  136 : AFRO MUSIC
 channel!137.meo.pt          		#  137 : TRACE TOCA HD
-channel!138.meo.pt          		#  138 : Trace Brazuca
+channel!138.meo.pt          		#  138 : Trace Brasil
 channel!139.meo.pt          		#  139 : ALMA LUSA
-channel!14.meo.pt           		#   14 : SPORT TV + HD
+channel!14.meo.pt           		#   14 : SPORT TV +
 channel!140.meo.pt          		#  140 : MEZZO
 channel!141.meo.pt          		#  141 : MEZZO Live HD
 channel!142.meo.pt          		#  142 : BOMSOM TV
@@ -43,61 +45,60 @@ channel!15.meo.pt           		#   15 : PORTO CANAL
 channel!151.meo.pt          		#  151 : STINGRAY ICONCERTS HD
 channel!152.meo.pt          		#  152 : STINGRAY LOUD HD
 channel!153.meo.pt          		#  153 : STINGRAY RETRO HD
-channel!160.meo.pt          		#  160 : RTP AÇORES HD
-channel!161.meo.pt          		#  161 : RTP MADEIRA
+channel!161.meo.pt          		#  161 : RTP MADEIRA HD
 channel!162.meo.pt          		#  162 : ARTV
 channel!163.meo.pt          		#  163 : LOCALVISÃO TV HD
-channel!170.meo.pt          		#  170 : TOROS HD
+channel!167.meo.pt          		#  167 : AZORES TV
 channel!172.meo.pt          		#  172 : CAÇA E PESCA HD
 channel!173.meo.pt          		#  173 : CAÇAVISION HD
+channel!174.meo.pt          		#  174 : OneToro TV
+channel!177.meo.pt          		#  177 : DOGTV HD
 channel!180.meo.pt          		#  180 : CANAL 180
 channel!181.meo.pt          		#  181 : Kuriakos TV HD
 channel!182.meo.pt          		#  182 : CANÇÃO NOVA HD
 channel!183.meo.pt          		#  183 : TV Verdade
 channel!184.meo.pt          		#  184 : UM Europa
-channel!186.meo.pt          		#  186 : DOGTV HD
+channel!185.meo.pt          		#  185 : Unifé TV
+channel!186.meo.pt          		#  186 : Novo Tempo
+channel!187.meo.pt          		#  187 : Gospel TV
 channel!189.meo.pt          		#  189 : PFC
 channel!190.meo.pt          		#  190 : GLOBO NEWS
 channel!191.meo.pt          		#  191 : RECORD TV HD
 channel!192.meo.pt          		#  192 : RECORD NEWS
 channel!195.meo.pt          		#  195 : EURONEWS
 channel!196.meo.pt          		#  196 : RTP ÁFRICA
+channel!197.meo.pt          		#  197 : Televisão África
 channel!199.meo.pt          		#  199 : TPA INTERNACIONAL
 channel=2.meo.pt            		#    2 : RTP 2
+channel!20.meo.pt           		#   20 : RTP AÇORES HD
 channel!202.meo.pt          		#  202 : TCV INTERNACIONAL
 channel!205.meo.pt          		#  205 : CNN
 channel!206.meo.pt          		#  206 : BLOOMBERG
 channel!209.meo.pt          		#  209 : CNBC
-channel!21.meo.pt           		#   21 : SPORT.TV1 HD
+channel!21.meo.pt           		#   21 : SPORT.TV1
 channel!211.meo.pt          		#  211 : SKY NEWS
+channel!212.meo.pt          		#  212 : English Club TV
 channel!214.meo.pt          		#  214 : BBC ENTERTAINMENT
 channel!216.meo.pt          		#  216 : FRANCE 24 (I)
 channel!217.meo.pt          		#  217 : i24 NEWS (I)
 channel!219.meo.pt          		#  219 : NHK WORLD JAPAN HD
-channel!22.meo.pt           		#   22 : SPORT.TV2 HD
+channel!22.meo.pt           		#   22 : SPORT.TV2
 channel!220.meo.pt          		#  220 : CGTN HD
 channel!221.meo.pt          		#  221 : CGTN-Documentary
+channel!222.meo.pt          		#  222 : ARIRANG TV
 channel!223.meo.pt          		#  223 : EURONEWS (I) HD
 channel!224.meo.pt          		#  224 : DEUTSCHE WELLE HD
 channel!225.meo.pt          		#  225 : AL JAZEERA ENGLISH HD
 channel!226.meo.pt          		#  226 : TRT World
-channel!227.meo.pt          		#  227 : RUSSIA TODAY (RT)
 channel!228.meo.pt          		#  228 : CHANNEL 1 RUSSIA
-channel!23.meo.pt           		#   23 : SPORT.TV3 HD
+channel!23.meo.pt           		#   23 : SPORT.TV3
 channel!234.meo.pt          		#  234 : TVEi
 channel!235.meo.pt          		#  235 : TVE24
 channel!236.meo.pt          		#  236 : TV GALÍCIA
 channel!239.meo.pt          		#  239 : TELESUR
-channel!24.meo.pt           		#   24 : SPORT.TV4 HD
+channel!24.meo.pt           		#   24 : SPORT.TV4
 channel!240.meo.pt          		#  240 : CUBAVISION
-channel!242.meo.pt          		#  242 : Antena 3 Internacional 
-channel!243.meo.pt          		#  243 : A3Series
-channel!244.meo.pt          		#  244 : A3Cine 
-channel!245.meo.pt          		#  245 : Somos
-channel!246.meo.pt          		#  246 : Sol Música
-channel!247.meo.pt          		#  247 : Cocina
-channel!248.meo.pt          		#  248 : Decasa
-channel!25.meo.pt           		#   25 : SPORT.TV5 HD
+channel!25.meo.pt           		#   25 : SPORT.TV5
 channel!250.meo.pt          		#  250 : TV5MONDE HD
 channel!251.meo.pt          		#  251 : BFM TV
 channel!253.meo.pt          		#  253 : BFM Business
@@ -107,7 +108,7 @@ channel!256.meo.pt          		#  256 : FRANCE 2
 channel!257.meo.pt          		#  257 : FRANCE 3
 channel!258.meo.pt          		#  258 : FRANCE 5
 channel!259.meo.pt          		#  259 : ARTE
-channel!26.meo.pt           		#   26 : SPORT.TV6 HD
+channel!26.meo.pt           		#   26 : SPORT.TV6
 channel!261.meo.pt          		#  261 : DEUTSCHE WELLE (A)
 channel!262.meo.pt          		#  262 : EURONEWS (A)
 channel!263.meo.pt          		#  263 : ARD
@@ -117,25 +118,26 @@ channel!266.meo.pt          		#  266 : 3SAT
 channel!267.meo.pt          		#  267 : KIKA
 channel!27.meo.pt           		#   27 : NBA TV 
 channel!270.meo.pt          		#  270 : BVN
-channel!271.meo.pt          		#  271 : INTER+
 channel!272.meo.pt          		#  272 : PRO TV INTERNACIONAL
 channel!273.meo.pt          		#  273 : BNT 4
 channel!277.meo.pt          		#  277 : KBS WORLD
-channel!279.meo.pt          		#  279 : CCTV 4 HD
+channel!278.meo.pt          		#  278 : CCTV 4 HD
+channel!279.meo.pt          		#  279 : PHOENIX CNE
 channel!28.meo.pt           		#   28 : FIGHT SPORTS
-channel!280.meo.pt          		#  280 : PHOENIX CNE
-channel!282.meo.pt          		#  282 : Ukraine 24
-channel!283.meo.pt          		#  283 : Ukraine 1
-channel!284.meo.pt          		#  284 : Ukraine 2
-channel!285.meo.pt          		#  285 : NLO TV2
-channel!286.meo.pt          		#  286 : Star Cinema
-channel!287.meo.pt          		#  287 : Star Family
-channel!288.meo.pt          		#  288 : X Sport
-channel!289.meo.pt          		#  289 : Rybalka TV
+channel!281.meo.pt          		#  281 : Freedom
+channel!282.meo.pt          		#  282 :  1+1 International
+channel!283.meo.pt          		#  283 : 1+1 United News
+channel!284.meo.pt          		#  284 : Kvartal TV International
+channel!285.meo.pt          		#  285 : Star Cinema
+channel!286.meo.pt          		#  286 : Star Family
+channel!287.meo.pt          		#  287 : X Sport
+channel!288.meo.pt          		#  288 : Duck TV
+channel!289.meo.pt          		#  289 : RAI Italia
+channel!29.meo.pt           		#   29 : W-Sport
 channel!290.meo.pt          		#  290 : RAI 1
 channel!291.meo.pt          		#  291 : RAI 2
 channel!292.meo.pt          		#  292 : RAI 3
-channel!293.meo.pt          		#  293 : RAI News24
+channel!293.meo.pt          		#  293 : RAI News
 channel!294.meo.pt          		#  294 : RAI Scuola
 channel!295.meo.pt          		#  295 : RAI Storia
 channel!296.meo.pt          		#  296 : ZEE TV
@@ -166,18 +168,18 @@ channel!38.meo.pt           		#   38 : EUROSPORT 1 HD
 channel!39.meo.pt           		#   39 : EUROSPORT 2 HD
 channel!4.meo.pt            		#    4 : TVI
 channel!40.meo.pt           		#   40 : DISNEY CHANNEL
-channel!400.meo.pt          		#  400 : MCS TV ULTRA HD
+channel!400.meo.pt          		#  400 : Travelxp 4K HDR
+channel!401.meo.pt          		#  401 : MCS TV ULTRA HD
 channel!41.meo.pt           		#   41 : CARTOON NETWORK
-channel!42.meo.pt           		#   42 : BIGGS
+channel!42.meo.pt           		#   42 : Panda KIDS
 channel!43.meo.pt           		#   43 : SIC K
 channel!44.meo.pt           		#   44 : NICKELODEON
 channel!45.meo.pt           		#   45 : Disney Junior
 channel!46.meo.pt           		#   46 : PANDA HD
-channel!47.meo.pt           		#   47 : JIMJAM
-channel!48.meo.pt           		#   48 : BABY TV
-channel!49.meo.pt           		#   49 : Lolly kids
+channel!47.meo.pt           		#   47 : Cartoonito
+channel!49.meo.pt           		#   49 : BABY TV
 channel!5.meo.pt            		#    5 : SIC NOTICIAS
-channel!50.meo.pt           		#   50 : Panda KIDS
+channel!50.meo.pt           		#   50 : Lolly kids
 channel!501.meo.pt          		#  501 : RTP 1
 channel!502.meo.pt          		#  502 : RTP 2
 channel!503.meo.pt          		#  503 : SIC
@@ -193,6 +195,8 @@ channel!512.meo.pt          		#  512 : TVI FICÇÃO
 channel!513.meo.pt          		#  513 : A BOLA TV
 channel!514.meo.pt          		#  514 : SPORT TV +
 channel!515.meo.pt          		#  515 : PORTO CANAL
+channel!52.meo.pt           		#   52 : NICK JR
+channel!520.meo.pt          		#  520 : RTP AÇORES
 channel!521.meo.pt          		#  521 : SPORT.TV1
 channel!522.meo.pt          		#  522 : SPORT.TV2
 channel!523.meo.pt          		#  523 : SPORT.TV3
@@ -209,24 +213,26 @@ channel!536.meo.pt          		#  536 : ELEVEN 6
 channel!537.meo.pt          		#  537 : SPORTING TV
 channel!538.meo.pt          		#  538 : EUROSPORT 1
 channel!539.meo.pt          		#  539 : EUROSPORT 2
+channel!54.meo.pt           		#   54 : BIGGS
 channel!540.meo.pt          		#  540 : DISNEY CHANNEL
+channel!541.meo.pt          		#  541 : CARTOON NETWORK
+channel!542.meo.pt          		#  542 : Panda KIDS
 channel!543.meo.pt          		#  543 : SIC K
 channel!545.meo.pt          		#  545 : DISNEY JUNIOR
 channel!546.meo.pt          		#  546 : PANDA
-channel!55.meo.pt           		#   55 : TVCine TOP HD
-channel!550.meo.pt          		#  550 : Panda KIDS
+channel!55.meo.pt           		#   55 : TVCine TOP
 channel!555.meo.pt          		#  555 : TVCine TOP
 channel!556.meo.pt          		#  556 : TVCINE Edition
 channel!557.meo.pt          		#  557 : TVCINE Emotion
 channel!558.meo.pt          		#  558 : TVCine Action
-channel!56.meo.pt           		#   56 : TVCINE Edition HD
+channel!56.meo.pt           		#   56 : TVCINE Edition
 channel!560.meo.pt          		#  560 : CINEMUNDO
 channel!561.meo.pt          		#  561 : HOLLYWOOD 
 channel!562.meo.pt          		#  562 : FOX MOVIES
 channel!563.meo.pt          		#  563 : AMC
 channel!564.meo.pt          		#  564 : AXN MOVIES
 channel!569.meo.pt          		#  569 : MEO VIDEOCLUBE
-channel!57.meo.pt           		#   57 : TVCINE Emotion HD
+channel!57.meo.pt           		#   57 : TVCINE Emotion
 channel!570.meo.pt          		#  570 : FOX
 channel!571.meo.pt          		#  571 : FOX LIFE
 channel!572.meo.pt          		#  572 : FOX CRIME
@@ -234,39 +240,40 @@ channel!573.meo.pt          		#  573 : FOX COMEDY
 channel!574.meo.pt          		#  574 : AXN
 channel!575.meo.pt          		#  575 : AXN WHITE
 channel!576.meo.pt          		#  576 : SYFY
-channel!58.meo.pt           		#   58 : TVCine Action HD
+channel!58.meo.pt           		#   58 : TVCine Action
 channel!589.meo.pt          		#  589 : MEO DESTAQUES
 channel!590.meo.pt          		#  590 : DISCOVERY CHANNEL
 channel!591.meo.pt          		#  591 : CANAL HISTÓRIA
 channel!592.meo.pt          		#  592 : ODISSEIA
 channel!595.meo.pt          		#  595 : NATIONAL GEOGRAPHIC CHANNEL
 channel!596.meo.pt          		#  596 : National Geographic Wild
-channel!599.meo.pt          		#  599 : TVI Reality – Big Brother Famosos
+channel!599.meo.pt          		#  599 : TVI Reality – Big Brother
 channel!6.meo.pt            		#    6 : RTP 3
 channel!60.meo.pt           		#   60 : CINEMUNDO HD
 channel!601.meo.pt          		#  601 : Q
 channel!605.meo.pt          		#  605 : SIC RADICAL
 channel!606.meo.pt          		#  606 : MTV Portugal
-channel!61.meo.pt           		#   61 : HOLLYWOOD HD
-channel!610.meo.pt          		#  610 : Crime + Investigation SD
-channel!615.meo.pt          		#  615 : Crime + Investigation 
-channel!62.meo.pt           		#   62 : FOX MOVIES HD
+channel!61.meo.pt           		#   61 : HOLLYWOOD
+channel!614.meo.pt          		#  614 : AMC Crime
+channel!618.meo.pt          		#  618 : TLC
+channel!62.meo.pt           		#   62 : FOX MOVIES
 channel!620.meo.pt          		#  620 : SIC CARAS
 channel!621.meo.pt          		#  621 : E! ENTERTAINMENT
 channel!623.meo.pt          		#  623 : 24 KITCHEN
 channel!626.meo.pt          		#  626 : FTV
+channel!628.meo.pt          		#  628 : MÁS CHIC
 channel!63.meo.pt           		#   63 : AMC HD
 channel!632.meo.pt          		#  632 : TRACE URBAN
 channel!634.meo.pt          		#  634 : MCM TOP
 channel!635.meo.pt          		#  635 : CLUBBING TV
 channel!64.meo.pt           		#   64 : AXN MOVIES HD
-channel!660.meo.pt          		#  660 : RTP AÇORES
+channel!661.meo.pt          		#  661 : RTP MADEIRA
 channel!663.meo.pt          		#  663 : LOCALVISÃO TV
-channel!670.meo.pt          		#  670 : TOROS
 channel!672.meo.pt          		#  672 : CAÇA E PESCA
 channel!673.meo.pt          		#  673 : CAÇAVISION
+channel!677.meo.pt          		#  677 : DOGTV
 channel!682.meo.pt          		#  682 : CANÇÃO NOVA
-channel!686.meo.pt          		#  686 : DOGTV
+channel!684.meo.pt          		#  684 : UM Europa
 channel!69.meo.pt           		#   69 : MEO VIDEOCLUBE HD
 channel!690.meo.pt          		#  690 : GLOBO NEWS
 channel!691.meo.pt          		#  691 : RECORD TV
@@ -274,19 +281,27 @@ channel!7.meo.pt            		#    7 : CNN Portugal
 channel!70.meo.pt           		#   70 : FOX HD
 channel!709.meo.pt          		#  709 : CNBC
 channel!71.meo.pt           		#   71 : FOX LIFE HD
-channel!72.meo.pt           		#   72 : FOX CRIME HD
+channel!717.meo.pt          		#  717 : i24 NEWS (I)
+channel!72.meo.pt           		#   72 : FOX CRIME
 channel!720.meo.pt          		#  720 : CGTN
 channel!723.meo.pt          		#  723 : EURONEWS (I)
 channel!725.meo.pt          		#  725 : AL JAZEERA ENGLISH
-channel!73.meo.pt           		#   73 : FOX COMEDY HD
+channel!73.meo.pt           		#   73 : FOX COMEDY
 channel!736.meo.pt          		#  736 : TV GALÍCIA
 channel!74.meo.pt           		#   74 : AXN HD
 channel!75.meo.pt           		#   75 : AXN WHITE HD
 channel!750.meo.pt          		#  750 : TV5MONDE
 channel!76.meo.pt           		#   76 : SYFY HD
 channel!77.meo.pt           		#   77 : DIZI CHANNEL
-channel!779.meo.pt          		#  779 : CCTV 4
+channel!778.meo.pt          		#  778 : CCTV 4
+channel!779.meo.pt          		#  779 : PHOENIX CNE
+channel!789.meo.pt          		#  789 : RAI Italia
 channel!790.meo.pt          		#  790 : RAI 1
+channel!791.meo.pt          		#  791 : RAI 2
+channel!792.meo.pt          		#  792 : RAI 3
+channel!793.meo.pt          		#  793 : RAI News24
+channel!794.meo.pt          		#  794 : RAI Scuola
+channel!795.meo.pt          		#  795 : RAI Storia
 channel!8.meo.pt            		#    8 : CMTV
 channel!89.meo.pt           		#   89 : MEO DESTAQUES HD
 channel!9.meo.pt            		#    9 : SIC MULHER
@@ -295,4 +310,4 @@ channel!91.meo.pt           		#   91 : CANAL HISTÓRIA HD
 channel!92.meo.pt           		#   92 : ODISSEIA HD
 channel!95.meo.pt           		#   95 : NATIONAL GEOGRAPHIC CHANNEL HD
 channel!96.meo.pt           		#   96 : National Geographic Wild HD
-channel!99.meo.pt           		#   99 : TVI Reality – Big Brother Famosos
+channel!99.meo.pt           		#   99 : TVI Reality – Big Brother

--- a/grab/pt_meo/tv_grab_pt_meo
+++ b/grab/pt_meo/tv_grab_pt_meo
@@ -455,7 +455,7 @@ sub get_programmes {
 	print STDERR " URL= $url \n" if $opt_debug;
 	t $url;
 
-	my $content = '{ service:"channelsguide", channels: ["'.$ch_meo_id.'"], dateStart:"'.$dt_start->strftime('%Y-%m-%d').'T00:00:00.000Z", dateEnd:"'.$dt_stop->strftime('%Y-%m-%d').'T00:00:00.000Z", accountID:"" }';
+	my $content = '{ "service": "channelsguide", "channels": ["'.$ch_meo_id.'"], "dateStart": "'.$dt_start->strftime('%Y-%m-%d').'T00:00:00.000Z", "dateEnd": "'.$dt_stop->strftime('%Y-%m-%d').'T00:00:00.000Z", "accountID": "" }';
 	print STDERR " BODY= $content \n" if $opt_debug;
 	t $content;
 
@@ -529,7 +529,7 @@ sub get_programmes {
 				print STDERR " URL= $url \n" if $opt_debug && !$debug_url_done; $debug_url_done=1;
 				t $url;
 
-				my $content = '{ service:"programdetail", programID:"'.$p_id.'", accountID:"" }';
+				my $content = '{ "service": "programdetail", "programID": "'.$p_id.'", "accountID": "" }';
 				print STDERR " BODY= $content \n" if $opt_debug;
 				t $content;
 

--- a/grab/pt_meo/tv_grab_pt_meo
+++ b/grab/pt_meo/tv_grab_pt_meo
@@ -451,7 +451,7 @@ sub get_programmes {
 	$ch_meo_id = toUTF8($ch_meo_id);
 	print STDERR " CH= $ch_meo_id \n" if $opt_debug;
 
-	my $url = 'https://www.meo.pt/_layouts/15/Ptsi.Isites.GridTv/GridTvMng.asmx/getProgramsFromChannels';
+	my $url = 'https://authservice.apps.meo.pt/Services/GridTv/GridTvMng.svc/getProgramsFromChannels';
 	print STDERR " URL= $url \n" if $opt_debug;
 	t $url;
 
@@ -525,7 +525,7 @@ sub get_programmes {
 			# get programme description from the programme page unless the user says no
 			if (!$opt_fast) {
 
-				my $url = 'https://www.meo.pt/_layouts/15/Ptsi.Isites.GridTv/GridTvMng.asmx/getProgramDetails';
+				my $url = 'https://authservice.apps.meo.pt/Services/GridTv/GridTvMng.svc/getProgramDetails';
 				print STDERR " URL= $url \n" if $opt_debug && !$debug_url_done; $debug_url_done=1;
 				t $url;
 
@@ -653,7 +653,7 @@ sub get_channels {
 	my ( %channels, %channellabels );
 
 	# retrieve channels
-	my $url = 'https://www.meo.pt/_layouts/15/Ptsi.Isites.GridTv/GridTvMng.asmx/getGridAnon';
+	my $url = 'https://authservice.apps.meo.pt/Services/GridTv/GridTvMng.svc/getGridAnon';
 	print STDERR " URL= $url \n" if $opt_debug;
 	t $url;
 

--- a/grab/pt_meo/tv_grab_pt_meo
+++ b/grab/pt_meo/tv_grab_pt_meo
@@ -104,7 +104,7 @@ use XMLTV::ProgressBar;
 use XMLTV::Ask;
 use XMLTV::Config_file;
 use XMLTV::DST;
-use XMLTV::Get_nice 0.005067;
+use XMLTV::Get_nice 0.005071;
 use XMLTV::Mode;
 use XMLTV::Capabilities qw/baseline manualconfig cache/;
 use XMLTV::Description 'Portugal';
@@ -460,7 +460,7 @@ sub get_programmes {
 	t $content;
 
 	# fetch json content (already decoded from utf8)
-	my $data = post_nice_json( $url, $content );
+	my $data = post_nice_json( $url, $content, 'Origin' => 'https://www.meo.pt' );
 	#print STDERR Dumper($data);die();
 
 	my $debug_url_done=0;	# for debug
@@ -533,7 +533,7 @@ sub get_programmes {
 				print STDERR " BODY= $content \n" if $opt_debug;
 				t $content;
 
-				my $data = post_nice_json( $url, $content );
+				my $data = post_nice_json( $url, $content, 'Origin' => 'https://www.meo.pt' );
 
 				#print STDERR Dumper($data);die();
 
@@ -662,7 +662,7 @@ sub get_channels {
 	t $content;
 
 	# fetch json content (already decoded from utf8)
-	my $data = post_nice_json( $url, $content );
+	my $data = post_nice_json( $url, $content, 'Origin' => 'https://www.meo.pt' );
 
 	foreach (@{ $data->{d}->{channels} }) {
 


### PR DESCRIPTION
What type of Pull Request is this?
----------------------------------
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
This PR fixes #208.

Please explain what this PR does
--------------------------------
`tv_grab_pt_meo` currently had several issues:
- the API endpoints have been moved to a different host/path;
- the JSON payloads being `POST`ed to the API were malformed (the structure remains the same), which were rejected by the "new" API;
- the API rejects requests without an `Origin` header matching `https://www.meo.pt`.

This PR addresses those issues, and extends [XMLTV::Get_nice::post_nice_json()](https://github.com/XMLTV/xmltv/blob/f84a264383266b63bcd57a5570c4079ce0535111/grab/Get_nice.pm#L195) to accept an **optional** hash of HTTP headers to be included in the HTTP request; I wasn't sure whether this would feel the right approach, but given this function [only appears to be used in `tv_grab_pt_meo`](https://github.com/search?q=repo%3AXMLTV%2Fxmltv%20post_nice_json&type=code) I thought it was ok. Any suggestions more than welcome.

Any other information?
----------------------
**I am not at all familiar with Perl**; read a couple of things to understand some of the basics, what was the meaning of the `$$` signature, ... I believe the changes "make sense", but I feel there might be some Perl-specifics I might be missing. Please advise if so.

This change **has not** been discussed on the xmltv-devel mailing list.

Where have you tested these changes?
------------------------------------
**Operating System:** Alpine Linux `v3.18.4`

**Perl Version:** `v5.36.1`
