### PR TITLE
tv_grab_zz_sdjson: improve episode/season metadata handling

### DIFF
--- a/grab/zz_sdjson/tv_grab_zz_sdjson
+++ b/grab/zz_sdjson/tv_grab_zz_sdjson
@@ -1265,11 +1265,17 @@ sub get_program_episode {
 	my $part = '';
 	my @result;
 
-	my $metadata = $details->{'metadata'}->[0]->{'Gracenote'};
-	if($metadata)
-	{
-		$season = _get_program_episode($metadata->{'season'}, $metadata->{'totalSeason'});
-		$episode = _get_program_episode($metadata->{'episode'}, $metadata->{'totalEpisodes'});
+	metadata: for my $metadata (@{$details->{'metadata'}}) {
+		while(my ($key, $value) = each %{$metadata}) {
+			# prefer Gracenote metadata but use first available as fallback
+			my $is_gracenote = $key eq 'Gracenote';
+			if ($is_gracenote || !(length($season) || length($episode))) {
+				$season = _get_program_episode($value->{'season'},  $value->{'totalSeason'});
+				$episode = _get_program_episode($value->{'episode'}, $value->{'totalEpisodes'});
+			}
+
+			last metadata if $is_gracenote;
+		}
 	}
 
 	my $multipart = $program->{'multipart'};


### PR DESCRIPTION
What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
#221 

Please explain what this PR does
--------------------------------
The program metadata from SD is an array of different providers. The previous code was specifically looking for 'Gracenote' provider in the first array element and ignoring everything else. For example, it seems the first element is now often 'TVmaze' (at least for the lineups I use) and the episode/season data was all being ignored.

The code now iterates over all the metadata providers generally preferring the earlier entries unless a later one looks more complete.

Where have you tested these changes?
------------------------------------
**Operating System:**
ubuntu 22.04

**Perl Version:**
v5.34.0

I have only tested this very quickly so far. I would like to do more testing / review before merging.  But I thought I would create the PR now in case @rob-vh who reported the issue wants to test it or is very eager for a fix.