### PR TITLE
Update tv_grab_fr so it works again

### DIFF
--- a/grab/fr/tv_grab_fr
+++ b/grab/fr/tv_grab_fr
@@ -36,11 +36,9 @@ my $GRABBER_VERSION  = "$XMLTV::VERSION";
 my $ROOT_URL                = "https://www.telestar.fr";
 my $GRID_FOR_CHANNEL        = "$ROOT_URL/programme-tv/";
 my $GRID_FOR_BOUQUET        = "$ROOT_URL/programme-tv/bouquets/";
-my $GRID_BY_CHANNEL_PER_DAY = "$ROOT_URL/programme-tv/grille-chaine/";
 
 my $ENCODING  = "utf-8";
 my $LANG      = "fr";
-my $MAX_RETRY = 5;
 
 my %tv_attributes = (
     'source-info-name'    => 'Tele Star',

--- a/grab/fr/tv_grab_fr
+++ b/grab/fr/tv_grab_fr
@@ -784,9 +784,14 @@ sub update_programme_stop_times {
                 debug_print("    There is a small gap of $gap minutes between '$p0_title' and '$p1_title'");
                 $p0->{stop} = $p1->{start};
             }
-            else {
-                # Otherwise, use the current programme's duration
-                debug_print("    There is a large gap of $gap minutes between '$p0_title' and '$p1_title'");
+            elsif ($p1_start->hour < 2 || $p0_stop->hour > 6) {
+                # Assume there should be no gap during 'daytime'
+                debug_print("    Ignoring a large daytime gap of $gap minutes between '$p0_title' and '$p1_title'");
+                $p0->{stop} = get_xmltv_time_from_datetime($p1_start);
+            } else {
+                # But in the middle of the night there may be no programme
+                # so use the current programme's duration
+                debug_print("    There is a large gap of $gap minutes at night between '$p0_title' and '$p1_title'");
                 $p0->{stop} = get_xmltv_time_from_datetime($p0_stop);
             }
         }

--- a/grab/fr/tv_grab_fr
+++ b/grab/fr/tv_grab_fr
@@ -33,7 +33,7 @@ use IO::Scalar;
 my $GRABBER_NAME     = 'tv_grab_fr';
 my $GRABBER_VERSION  = "$XMLTV::VERSION";
 
-my $ROOT_URL                = "https://www.telestar.fr";
+my $ROOT_URL                = "https://www.telepoche.fr";
 my $GRID_FOR_CHANNEL        = "$ROOT_URL/programme-tv/";
 my $GRID_FOR_BOUQUET        = "$ROOT_URL/programme-tv/bouquets/";
 
@@ -41,8 +41,8 @@ my $ENCODING  = "utf-8";
 my $LANG      = "fr";
 
 my %tv_attributes = (
-    'source-info-name'    => 'Tele Star',
-    'source-info-url'     => 'telestar.tv',
+    'source-info-name'    => 'Tele Poche',
+    'source-info-url'     => 'telepoche.tv',
     'source-data-url'     => "$GRID_FOR_CHANNEL",
     'generator-info-name' => "XMLTV/$XMLTV::VERSION, $GRABBER_NAME",
 );
@@ -50,7 +50,7 @@ my %tv_attributes = (
 my ( $opt, $conf ) = ParseOptions( {
     grabber_name => "$GRABBER_NAME",
     version => "$GRABBER_VERSION",
-    description => "France (Tele Star)",
+    description => "France (Tele Poche)",
     capabilities => [qw/baseline manualconfig cache apiconfig/],
     defaults => { days => 14, offset => 0, quiet => 0, debug => 0, slow => 0 },
     extra_options => [qw/slow/],
@@ -954,7 +954,7 @@ __END__
 
 =head1 NAME
 
-tv_grab_fr - Grab TV listings for France (Télé Star).
+tv_grab_fr - Grab TV listings for France (Télé Poche).
 
 =head1 SYNOPSIS
 
@@ -982,7 +982,7 @@ tv_grab_fr - Grab TV listings for France (Télé Star).
 
 Output TV listings for many channels available in France (Orange,
 Free, cable/ADSL/satellite, Canal+ Sat).  The data comes from
-Télé Star (telestar.fr).  The default is to grab 14 days.
+Télé Poche (telepoche.fr).  The default is to grab 14 days.
 
 B<--configure> Choose which bouquet/channels to grab listings data for.
 
@@ -1026,7 +1026,7 @@ L<xmltv(5)>
 =head1 AUTHOR
 
 The current tv_grab_fr script was rewritten by Nick Morrott,
-knowledgejunkie at gmail dot com, to support the new telestar.fr site.
+knowledgejunkie at gmail dot com, to support the new telepoche.fr site.
 
 =cut
 

--- a/grab/fr/tv_grab_fr
+++ b/grab/fr/tv_grab_fr
@@ -989,6 +989,9 @@ Output TV listings for many channels available in France (Orange,
 Free, cable/ADSL/satellite, Canal+ Sat).  The data comes from
 Télé Poche (telepoche.fr).  The default is to grab 14 days.
 
+Note that this source usually does not have data for night programmes (between
+midnight and 5 am).
+
 B<--configure> Choose which bouquet/channels to grab listings data for.
 
 B<--list-channels> List available channels.


### PR DESCRIPTION
This pull request contains the following changes:
- tv_grab_fr stopped working a few months ago. The reason is that whereas the full TV listings used to be available on both the telestar.fr and telepoche.fr websites, now the telestar.fr website has only a limited subset of the TV listings and in a different format from that expected by tv_grab_fr. The full TV listings are now only available on the telepoche.fr website.
- This pull request also improves handling of gaps between programmes: when there are multiple episodes of the same series back to back the source often only has the first episode start time and duration! That can result in pretty large gaps so it's best to ignore them, at least during daytime.
- Finally this adds a note to warn users that Télé Poche does not have programme data between midnight and 5 am (i.e. programmes that start during that period).

With these changes I can again get TV listings in MythTV on Debian 12.