### PR TITLE
Adapts tv_grab_pt_vodafone to new API version

### DIFF
--- a/grab/pt_vodafone/channel.list
+++ b/grab/pt_vodafone/channel.list
@@ -1,0 +1,142 @@
+2670	SIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/807cd0cdbf314c44a0a5d9c852b2f835_19/version/0/width/120/height/75/quality/100
+2671	TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a70ebda1d51b436d909cebf8b424b10e/version/0/width/120/height/75/quality/100
+2673	História SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ffe30fdefa448ec8571115ff786ef14_19/version/0/width/120/height/75/quality/100
+2674	SyFy SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/656c66e4f9784c5aacfe8a056df4e4b3_19/version/0/width/120/height/75/quality/100
+2675	Eurosport	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9e5ca9dad53a4dc88a3e0eb367015327_19/version/0/width/120/height/75/quality/100
+2687	Sport TV 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a524ac5886ff494086e707103e124cc7/version/0/width/120/height/75/quality/100
+2688	Sport TV 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2f08d170f2a34e6390eb533a3d86538e/version/0/width/120/height/75/quality/100
+2689	Sport TV 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bae1291a65b240abbc98c8d92f7d9718/version/0/width/120/height/75/quality/100
+2690	Sport TV 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/316b4ac356244f4f96c4c64b05946be3/version/0/width/120/height/75/quality/100
+2691	Sport TV 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/27da1d086e1e4a8a9e3003d3ef5e5f4e/version/0/width/120/height/75/quality/100
+2692	Fuel TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/721d0d21b99c4b239ccb9b2daf54596c_19/version/0/width/120/height/75/quality/100
+2700	AXN Movies	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/37500ae831f84b30822e5bd5e04fd882_19/version/0/width/120/height/75/quality/100
+2701	SyFy	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a0409944e5542a9b5acb0647467203a_19/version/0/width/120/height/75/quality/100
+2706	Fashion TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/0b7ab6b146da42d582433ebde0ee70ee_19/version/0/width/120/height/75/quality/100
+2709	Canção Nova	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5604f4864c104703bb3b46ec71f91114_19/version/0/width/120/height/75/quality/100
+2710	TV Galícia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3af7d6ee83df46d7ab1d30a3c072e61d_19/version/0/width/120/height/75/quality/100
+2712	TVCine Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2723399dc06b4b9e8914b29467e23dab_19/version/0/width/120/height/75/quality/100
+2713	AXN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a44800b441224087aea741f0bf74263c_19/version/0/width/120/height/75/quality/100
+2715	STAR CHANNEL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/777adf78621046109570913715ab336c_19/version/1/width/120/height/75/quality/100
+2717	STAR LIFE	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5022d2f187a646d696cb57f977a0c9d1_19/version/1/width/120/height/75/quality/100
+2723	Trace Toca	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3178257df111483684efa8efb63e5309_19/version/0/width/120/height/75/quality/100
+2727	RTP Memória	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/79a94c670a9943d895f2eaca4e72780b_19/version/0/width/120/height/75/quality/100
+2728	RTP África	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b61b8cc6bbaf4aa6961861c2e072290e_19/version/0/width/120/height/75/quality/100
+2736	AR TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3cef63b6677f451d8164a908b6a1aa00_19/version/0/width/120/height/75/quality/100
+2741	National Geographic	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dfe23167f5144543bab68ea436dd1d15_19/version/0/width/120/height/75/quality/100
+2742	TV5Monde	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fd9db0bfa1e74eaeb29f0034eec69fa2_19/version/0/width/120/height/75/quality/100
+2743	CMUSIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b94207010d994916a318e040c2d22f72_19/version/0/width/120/height/75/quality/100
+2744	Baby TV SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6e324dd3e2db4ca6998cf6a1bb73870d_19/version/0/width/120/height/75/quality/100
+2747	Euronews	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3346c27cb8044e5dbc17548d9610e2e8_19/version/0/width/120/height/75/quality/100
+2748	TVEi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dd60890cbbbf4704a89968766f0a1c3a_19/version/0/width/120/height/75/quality/100
+2749	TVE 24	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a861422493ed454994f7b7a69183846b_19/version/0/width/120/height/75/quality/100
+2750	CNBC Europe	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/969b0d2e8fe74a0db71c223f404f0ac6_19/version/0/width/120/height/75/quality/100
+2751	TPA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4e002a07acb84b02a86a19dba5ee102e_19/version/0/width/120/height/75/quality/100
+2754	MTV 00s 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c7f1040e19d940da8eec26928c0319de/version/0/width/120/height/75/quality/100
+2757	ProTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25f5f1ac6ede4d65ab0ebf0f05908088_19/version/0/width/120/height/75/quality/100
+2760	Bloomberg	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/aa36677a7a9941af9e07444dd21b525d_19/version/0/width/120/height/75/quality/100
+2765	Nautical Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ecdccfb21a5429e8d44bf2f29e4dd34_19/version/0/width/120/height/75/quality/100
+2766	Phoenix	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1957a8e6b0c44b66ab2e0ad91fbec763_19/version/0/width/120/height/75/quality/100
+2768	Porto Canal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/16cdb28b90cb46b1aee589be8a477eff_19/version/0/width/120/height/75/quality/100
+2769	France 24 English	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d575daeef80442598a33b1cffa5a21a5_19/version/0/width/120/height/75/quality/100
+2770	France 24 FR	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e5013d5b45304e77a8911ae9d76c59ea_19/version/0/width/120/height/75/quality/100
+2772	RAI 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/30137cc9eb7f472bb80cfbea196f524d_19/version/0/width/120/height/75/quality/100
+2779	MCM Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/18855da1bce845b7b7611689f2303f8b_19/version/0/width/120/height/75/quality/100
+2781	DW	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/be6a088466484a99a99842ec524895f6_19/version/0/width/120/height/75/quality/100
+2784	AlJazeera	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/803a229c5eb146ba90f22a763c49c0c7_19/version/0/width/120/height/75/quality/100
+2812	Record News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f7b7a4b51ead4f5d8028669c0287ff7c_19/version/0/width/120/height/75/quality/100
+2825	RTP2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f47f5f7d4acd493891cb1225d10024e2_19/version/0/width/120/height/75/quality/100
+2831	TVCine Emotion	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c3a60cce67a347ecad3ae6fae99e1646_19/version/0/width/120/height/75/quality/100
+2832	TVCine Action	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c47a0066a7244f51beeeba84fbf46424_19/version/0/width/120/height/75/quality/100
+2833	AXN White	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f54c7528c31947c8be68f13748cd15b0_19/version/0/width/120/height/75/quality/100
+2837	E!	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/502684fe51d24e6cb81551b3b2d54ca9_19/version/0/width/120/height/75/quality/100
+2843	Localvisão	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c704554bdcac437490143bc61b9aec87_19/version/0/width/120/height/75/quality/100
+2844	24Kitchen	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/481cf968448d4b07b8c675552a16ef8a_19/version/0/width/120/height/75/quality/100
+2845	STAR MOVIES	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3e7474629a5b416c8deaf0919002e6df_19/version/1/width/120/height/75/quality/100
+2846	National Geographic Wild	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b253e37f1334406f8e93c4b1c37470de_19/version/0/width/120/height/75/quality/100
+2847	STAR CRIME	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25769e8d419c4ea6b63d8097352b9cae_19/version/1/width/120/height/75/quality/100
+2849	Sky News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4d862190e6c549ad8f006f429ac53e52_19/version/0/width/120/height/75/quality/100
+2852	Benfica TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/477cd7f5a7354324b6a9a27db865708f_19/version/0/width/120/height/75/quality/100
+2854	TV Record	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/36bba6cd2b5746dc9a073e3e7817ec30_19/version/0/width/120/height/75/quality/100
+2859	RTL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ed68fc2259e34e329d66e4974331526a_19/version/0/width/120/height/75/quality/100
+2884	TCV News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cb1a4d4cc1b0472eb67ce43136c8f332_19/version/0/width/120/height/75/quality/100
+2890	NHK World	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf86b0c0b7714c90a27e881bbbb61ecc_19/version/0/width/120/height/75/quality/100
+2893	STAR COMEDY	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ea358343e7c4465c93ad1872e52ff0d6_19/version/1/width/120/height/75/quality/100
+2897	KBS WORLD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e23a084076eb46cabc7a2fce55e6c113_19/version/0/width/120/height/75/quality/100
+2902	Canal Q	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e1ebf412bd444a61afdd2d9fa1263e1a_19/version/0/width/120/height/75/quality/100
+2903	Fight Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4dcc70dcdde34d708b9ec9b1a861c8ad_19/version/0/width/120/height/75/quality/100
+2914	Discovery	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fa191c5ad6ba48b9bca783dafabc7498_19/version/0/width/120/height/75/quality/100
+2915	SIC Radical	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5a461799731d4344b277dcae381f0a89_19/version/0/width/120/height/75/quality/100
+2925	MTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9108b7d984a54a43b441bb44b9a84b85_19/version/0/width/120/height/75/quality/100
+2927	Kuriakos TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57feab802d804da792867ebeacd0db17_19/version/0/width/120/height/75/quality/100
+2930	Sport TV +	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ce24543d73ab43b1b53dea9dc25d6854/version/0/width/120/height/75/quality/100
+2931	Mezzo Live	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/24f9fa496e70422a9830c2549dd1de0f_19/version/0/width/120/height/75/quality/100
+2933	Insight	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08526de0382f4a2095f6063d7a7490cd_19/version/0/width/120/height/75/quality/100
+2934	Docubox	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/efb948f799c2406187f8e3dcf9e29b1d_19/version/0/width/120/height/75/quality/100
+2935	SIC Notícias	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf33e03117ac4ece8cc3b260d4869c4a/version/0/width/120/height/75/quality/100
+2936	SIC Mulher	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c23aa79c4be64a78be3ea5843c079529_19/version/0/width/120/height/75/quality/100
+2937	SIC Caras	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/71c7fa677b894fecada52f4fdb1defb5_19/version/0/width/120/height/75/quality/100
+2938	SIC K	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e45f250d72334fbdb3dbe1d91c4bc751_19/version/0/width/120/height/75/quality/100
+2993	Travel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9487453658fd42d9a8e515ee072328e7_19/version/0/width/120/height/75/quality/100
+2994	Food Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57a9e479ba34434a8ef249b0cd560c94_19/version/0/width/120/height/75/quality/100
+2996	AMC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1b0fa6a1c5544a24bdea82e2bc9222e3_19/version/0/width/120/height/75/quality/100
+3004	Sporting TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/868cdc88b86b4033a6be7fd2652bd05e_19/version/0/width/120/height/75/quality/100
+3012	Disney Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2887957962b24db6beee92d0b470a54c_19/version/0/width/120/height/75/quality/100
+3015	Trace	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bc50304a4b45406595c55d24d0c3ff01_19/version/0/width/120/height/75/quality/100
+3016	Odisseia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/121e6e261b8749749c53c4248026ee49_19/version/0/width/120/height/75/quality/100
+3017	AMC Break	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/af39b08b3262477cbfd49e8a506855d4_19/version/1/width/120/height/75/quality/100
+3019	ARIRANG TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/083bfe803259450b9e59de9d799ae2b6_19/version/0/width/120/height/75/quality/100
+3020	TV Globo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f3715346f3e748c088eeacef18bef34b_19/version/0/width/120/height/75/quality/100
+3024	TVCine Edition	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6ba9073760e2487488ada139d1b1f7b7_19/version/0/width/120/height/75/quality/100
+3026	Hollywood	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d3a18b81bedc48c6aaf41b64c3d570fd_19/version/0/width/120/height/75/quality/100
+3027	Cinemundo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/653fc31c29e34d62a434156b905c7cff_19/version/0/width/120/height/75/quality/100
+3028	RTP1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a1bef425c634497b9341957d36e692c3_19/version/0/width/120/height/75/quality/100
+3414	CMTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9059345359844b3ca594134c8d81ffc0_19/version/0/width/120/height/75/quality/100
+3885	DAZN 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e9ce8b8d6d2e48df8e096cd271cc982d/version/1/width/120/height/75/quality/100
+3886	DAZN 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08734341d4c9452dbe272112d5a3aaee/version/1/width/120/height/75/quality/100
+3887	DAZN 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7c03993042f64f2e80b224a52c87f6e7/version/1/width/120/height/75/quality/100
+3888	DAZN 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9f8ed7e32fb04f819475d9eb5a38d2d5/version/1/width/120/height/75/quality/100
+3889	DAZN 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/53aa4f7847834e1f8678067be941c238/version/1/width/120/height/75/quality/100
+3890	DAZN  6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2e6186034d444f83b0bf2a87836d123b/version/1/width/120/height/75/quality/100
+4862	SportTV NBA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e0b906090d974186914f5cc909c5dce6/version/0/width/120/height/75/quality/100
+5043	EuroSport 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/13130dde270143ea90c7ad709cd33cda_19/version/0/width/120/height/75/quality/100
+5583	A Bola TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/81847fc044e84e7f8f3fc9b7a1cb7d01_19/version/1/width/120/height/75/quality/100
+5585	Canal 11	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3c6048c60dc042fd84e395b33d1f049e_19/version/0/width/120/height/75/quality/100
+5609	S+	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c63940e416dd47b28de10aa3477408b0_19/version/0/width/120/height/75/quality/100
+5610	FREEDOM	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/309a6fca4d47427ca9f5c8145a0348c1/version/0/width/120/height/75/quality/100
+5678	CNN Portugal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/15dc865f76db4f7baddb09d728bd1088/version/0/width/120/height/75/quality/100
+7075	GameToon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/28aac14ad6f7411092bc81bc383cc85b_19/version/0/width/120/height/75/quality/100
+7084	RTP Açores	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7e72b63606b74facb84d4a4be512ef6b_19/version/0/width/120/height/75/quality/100
+7090	Casa e Cozinha	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e465476b8a8545488e8310c1df29e55d_19/version/0/width/120/height/75/quality/100
+7185	Panda	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/85009bcb0b8b45e7bc140a4832ca014b_19/version/0/width/120/height/75/quality/100
+7187	RTP3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d430a0822b5f469ca320bf6d6723f0ca_19/version/0/width/120/height/75/quality/100
+7188	Panda Kids	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9352c739e9b34d7b9aad308b90f521e7_19/version/0/width/120/height/75/quality/100
+7250	Sport TV 6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f31ce4c726dd4382915bfdea05a3c50f/version/0/width/120/height/75/quality/100
+7522	Disney Junior	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bbbf77ecab4440d0876889aa0d62b586/version/0/width/120/height/75/quality/100
+8005	Cartoonito	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/14dd98d3e0574155bf9e8dee613d3161_19/version/2/width/120/height/75/quality/100
+8006	Cartoon Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/23dffe336ee24fba9879f8b43eb49571_19/version/0/width/120/height/75/quality/100
+8013	GINX Esports TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25a531732c4d4ff99bab6793ad20be65_19/version/0/width/120/height/75/quality/100
+8124	iConcerts	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/655bd3fbd7764b85b6c216cf352fa320_19/version/0/width/120/height/75/quality/100
+8368	UNIFE TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2b0d86675bb8428e91c55eada3982d01_19/version/0/width/120/height/75/quality/100
+8396	CNN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/48a5c03f05264f969c71e56992a98847_19/version/1/width/120/height/75/quality/100
+8397	TVI Reality	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/8ae0590068384f8b85de367df743188e_19/version/1/width/120/height/75/quality/100
+8398	TLC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd02f77c26cb4380a1da6a2fe90a938d_19/version/1/width/120/height/75/quality/100
+8399	V+ TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e2cbe6f3c7de4a77a37e4eb878b789f7_19/version/2/width/120/height/75/quality/100
+8424	RTP Madeira	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d6249f5eef264202874dfdd5de492a9e_19/version/1/width/120/height/75/quality/100
+8426	AMC Crime	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d01e00520a5a4a2aaa1e1bf32f199dd5_19/version/1/width/120/height/75/quality/100
+8529	Dizi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/87e626cfaddd45bba7703e3df96d2c38_19/version/0/width/120/height/75/quality/100
+8598	BenficaTV Multicam 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7ba831b33ef34380b3b5b462bbf355cf/version/0/width/120/height/75/quality/100
+8599	BenficaTV Multicam 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6d713fb010f543a7a1e9848d6c791620/version/0/width/120/height/75/quality/100
+8600	BenficaTV Multicam 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/370959aa138a4805886fccabf38265e0/version/0/width/120/height/75/quality/100
+8601	BenficaTV Multicam 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b02508077c564f7883f8fc860f15b9c9/version/0/width/120/height/75/quality/100
+8606	AfroMusic 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b22774537d39440495b205b428e83a7f/version/0/width/120/height/75/quality/100
+8636	Panda Biggs	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/383f7e6f14ba48a0a69bde850dae7f50/version/0/width/120/height/75/quality/100
+8645	Nickelodeon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a5f17d29c7d4e74bea71046ffc50569/version/0/width/120/height/75/quality/100
+8646	MCM POP	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/610a1c775a4d4f89954924575c738b0e/version/0/width/120/height/75/quality/100
+8711	News Now 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7d1df4bc7fd948e3bbb57fefe3845ffb/version/0/width/120/height/75/quality/100
+8735	SIC Novelas	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd9e43272bc04420969e8e8ff0de8f8c/version/0/width/120/height/75/quality/100
+8743	Sport TV 7	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/079ac81d79f7490e844af481e5303d12/version/2/width/120/height/75/quality/100
+8775	HGTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/89768f1e6c1043279925acef9cadf5b8/version/0/width/120/height/75/quality/100
+8776	Disc ID	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5aa45346d01440dabf96211bf118c28f/version/0/width/120/height/75/quality/100
+8781	BabyTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b422dbbb9fec4df5a07b6a383d906d56/version/0/width/120/height/75/quality/100
+8782	TCV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4280bb15af7b45068bbd15138531050b/version/0/width/120/height/75/quality/100
+8783	História	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f16aac14d6d54c8bb723397b3d743f08/version/0/width/120/height/75/quality/100

--- a/grab/pt_vodafone/channel.list
+++ b/grab/pt_vodafone/channel.list
@@ -1,142 +1,260 @@
-2670	SIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/807cd0cdbf314c44a0a5d9c852b2f835_19/version/0/width/120/height/75/quality/100
-2671	TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a70ebda1d51b436d909cebf8b424b10e/version/0/width/120/height/75/quality/100
-2673	História SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ffe30fdefa448ec8571115ff786ef14_19/version/0/width/120/height/75/quality/100
-2674	SyFy SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/656c66e4f9784c5aacfe8a056df4e4b3_19/version/0/width/120/height/75/quality/100
-2675	Eurosport	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9e5ca9dad53a4dc88a3e0eb367015327_19/version/0/width/120/height/75/quality/100
-2687	Sport TV 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a524ac5886ff494086e707103e124cc7/version/0/width/120/height/75/quality/100
-2688	Sport TV 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2f08d170f2a34e6390eb533a3d86538e/version/0/width/120/height/75/quality/100
-2689	Sport TV 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bae1291a65b240abbc98c8d92f7d9718/version/0/width/120/height/75/quality/100
-2690	Sport TV 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/316b4ac356244f4f96c4c64b05946be3/version/0/width/120/height/75/quality/100
-2691	Sport TV 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/27da1d086e1e4a8a9e3003d3ef5e5f4e/version/0/width/120/height/75/quality/100
-2692	Fuel TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/721d0d21b99c4b239ccb9b2daf54596c_19/version/0/width/120/height/75/quality/100
-2700	AXN Movies	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/37500ae831f84b30822e5bd5e04fd882_19/version/0/width/120/height/75/quality/100
-2701	SyFy	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a0409944e5542a9b5acb0647467203a_19/version/0/width/120/height/75/quality/100
-2706	Fashion TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/0b7ab6b146da42d582433ebde0ee70ee_19/version/0/width/120/height/75/quality/100
-2709	Canção Nova	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5604f4864c104703bb3b46ec71f91114_19/version/0/width/120/height/75/quality/100
-2710	TV Galícia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3af7d6ee83df46d7ab1d30a3c072e61d_19/version/0/width/120/height/75/quality/100
-2712	TVCine Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2723399dc06b4b9e8914b29467e23dab_19/version/0/width/120/height/75/quality/100
-2713	AXN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a44800b441224087aea741f0bf74263c_19/version/0/width/120/height/75/quality/100
-2715	STAR CHANNEL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/777adf78621046109570913715ab336c_19/version/1/width/120/height/75/quality/100
-2717	STAR LIFE	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5022d2f187a646d696cb57f977a0c9d1_19/version/1/width/120/height/75/quality/100
-2723	Trace Toca	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3178257df111483684efa8efb63e5309_19/version/0/width/120/height/75/quality/100
-2727	RTP Memória	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/79a94c670a9943d895f2eaca4e72780b_19/version/0/width/120/height/75/quality/100
-2728	RTP África	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b61b8cc6bbaf4aa6961861c2e072290e_19/version/0/width/120/height/75/quality/100
-2736	AR TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3cef63b6677f451d8164a908b6a1aa00_19/version/0/width/120/height/75/quality/100
-2741	National Geographic	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dfe23167f5144543bab68ea436dd1d15_19/version/0/width/120/height/75/quality/100
-2742	TV5Monde	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fd9db0bfa1e74eaeb29f0034eec69fa2_19/version/0/width/120/height/75/quality/100
-2743	CMUSIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b94207010d994916a318e040c2d22f72_19/version/0/width/120/height/75/quality/100
-2744	Baby TV SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6e324dd3e2db4ca6998cf6a1bb73870d_19/version/0/width/120/height/75/quality/100
-2747	Euronews	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3346c27cb8044e5dbc17548d9610e2e8_19/version/0/width/120/height/75/quality/100
-2748	TVEi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dd60890cbbbf4704a89968766f0a1c3a_19/version/0/width/120/height/75/quality/100
-2749	TVE 24	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a861422493ed454994f7b7a69183846b_19/version/0/width/120/height/75/quality/100
-2750	CNBC Europe	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/969b0d2e8fe74a0db71c223f404f0ac6_19/version/0/width/120/height/75/quality/100
-2751	TPA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4e002a07acb84b02a86a19dba5ee102e_19/version/0/width/120/height/75/quality/100
-2754	MTV 00s 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c7f1040e19d940da8eec26928c0319de/version/0/width/120/height/75/quality/100
-2757	ProTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25f5f1ac6ede4d65ab0ebf0f05908088_19/version/0/width/120/height/75/quality/100
-2760	Bloomberg	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/aa36677a7a9941af9e07444dd21b525d_19/version/0/width/120/height/75/quality/100
-2765	Nautical Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ecdccfb21a5429e8d44bf2f29e4dd34_19/version/0/width/120/height/75/quality/100
-2766	Phoenix	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1957a8e6b0c44b66ab2e0ad91fbec763_19/version/0/width/120/height/75/quality/100
-2768	Porto Canal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/16cdb28b90cb46b1aee589be8a477eff_19/version/0/width/120/height/75/quality/100
-2769	France 24 English	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d575daeef80442598a33b1cffa5a21a5_19/version/0/width/120/height/75/quality/100
-2770	France 24 FR	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e5013d5b45304e77a8911ae9d76c59ea_19/version/0/width/120/height/75/quality/100
-2772	RAI 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/30137cc9eb7f472bb80cfbea196f524d_19/version/0/width/120/height/75/quality/100
-2779	MCM Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/18855da1bce845b7b7611689f2303f8b_19/version/0/width/120/height/75/quality/100
-2781	DW	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/be6a088466484a99a99842ec524895f6_19/version/0/width/120/height/75/quality/100
-2784	AlJazeera	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/803a229c5eb146ba90f22a763c49c0c7_19/version/0/width/120/height/75/quality/100
-2812	Record News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f7b7a4b51ead4f5d8028669c0287ff7c_19/version/0/width/120/height/75/quality/100
-2825	RTP2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f47f5f7d4acd493891cb1225d10024e2_19/version/0/width/120/height/75/quality/100
-2831	TVCine Emotion	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c3a60cce67a347ecad3ae6fae99e1646_19/version/0/width/120/height/75/quality/100
-2832	TVCine Action	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c47a0066a7244f51beeeba84fbf46424_19/version/0/width/120/height/75/quality/100
-2833	AXN White	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f54c7528c31947c8be68f13748cd15b0_19/version/0/width/120/height/75/quality/100
-2837	E!	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/502684fe51d24e6cb81551b3b2d54ca9_19/version/0/width/120/height/75/quality/100
-2843	Localvisão	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c704554bdcac437490143bc61b9aec87_19/version/0/width/120/height/75/quality/100
-2844	24Kitchen	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/481cf968448d4b07b8c675552a16ef8a_19/version/0/width/120/height/75/quality/100
-2845	STAR MOVIES	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3e7474629a5b416c8deaf0919002e6df_19/version/1/width/120/height/75/quality/100
-2846	National Geographic Wild	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b253e37f1334406f8e93c4b1c37470de_19/version/0/width/120/height/75/quality/100
-2847	STAR CRIME	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25769e8d419c4ea6b63d8097352b9cae_19/version/1/width/120/height/75/quality/100
-2849	Sky News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4d862190e6c549ad8f006f429ac53e52_19/version/0/width/120/height/75/quality/100
-2852	Benfica TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/477cd7f5a7354324b6a9a27db865708f_19/version/0/width/120/height/75/quality/100
-2854	TV Record	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/36bba6cd2b5746dc9a073e3e7817ec30_19/version/0/width/120/height/75/quality/100
-2859	RTL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ed68fc2259e34e329d66e4974331526a_19/version/0/width/120/height/75/quality/100
-2884	TCV News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cb1a4d4cc1b0472eb67ce43136c8f332_19/version/0/width/120/height/75/quality/100
-2890	NHK World	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf86b0c0b7714c90a27e881bbbb61ecc_19/version/0/width/120/height/75/quality/100
-2893	STAR COMEDY	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ea358343e7c4465c93ad1872e52ff0d6_19/version/1/width/120/height/75/quality/100
-2897	KBS WORLD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e23a084076eb46cabc7a2fce55e6c113_19/version/0/width/120/height/75/quality/100
-2902	Canal Q	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e1ebf412bd444a61afdd2d9fa1263e1a_19/version/0/width/120/height/75/quality/100
-2903	Fight Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4dcc70dcdde34d708b9ec9b1a861c8ad_19/version/0/width/120/height/75/quality/100
-2914	Discovery	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fa191c5ad6ba48b9bca783dafabc7498_19/version/0/width/120/height/75/quality/100
-2915	SIC Radical	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5a461799731d4344b277dcae381f0a89_19/version/0/width/120/height/75/quality/100
-2925	MTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9108b7d984a54a43b441bb44b9a84b85_19/version/0/width/120/height/75/quality/100
-2927	Kuriakos TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57feab802d804da792867ebeacd0db17_19/version/0/width/120/height/75/quality/100
-2930	Sport TV +	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ce24543d73ab43b1b53dea9dc25d6854/version/0/width/120/height/75/quality/100
-2931	Mezzo Live	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/24f9fa496e70422a9830c2549dd1de0f_19/version/0/width/120/height/75/quality/100
-2933	Insight	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08526de0382f4a2095f6063d7a7490cd_19/version/0/width/120/height/75/quality/100
-2934	Docubox	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/efb948f799c2406187f8e3dcf9e29b1d_19/version/0/width/120/height/75/quality/100
-2935	SIC Notícias	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf33e03117ac4ece8cc3b260d4869c4a/version/0/width/120/height/75/quality/100
-2936	SIC Mulher	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c23aa79c4be64a78be3ea5843c079529_19/version/0/width/120/height/75/quality/100
-2937	SIC Caras	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/71c7fa677b894fecada52f4fdb1defb5_19/version/0/width/120/height/75/quality/100
-2938	SIC K	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e45f250d72334fbdb3dbe1d91c4bc751_19/version/0/width/120/height/75/quality/100
-2993	Travel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9487453658fd42d9a8e515ee072328e7_19/version/0/width/120/height/75/quality/100
-2994	Food Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57a9e479ba34434a8ef249b0cd560c94_19/version/0/width/120/height/75/quality/100
-2996	AMC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1b0fa6a1c5544a24bdea82e2bc9222e3_19/version/0/width/120/height/75/quality/100
-3004	Sporting TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/868cdc88b86b4033a6be7fd2652bd05e_19/version/0/width/120/height/75/quality/100
-3012	Disney Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2887957962b24db6beee92d0b470a54c_19/version/0/width/120/height/75/quality/100
-3015	Trace	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bc50304a4b45406595c55d24d0c3ff01_19/version/0/width/120/height/75/quality/100
-3016	Odisseia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/121e6e261b8749749c53c4248026ee49_19/version/0/width/120/height/75/quality/100
-3017	AMC Break	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/af39b08b3262477cbfd49e8a506855d4_19/version/1/width/120/height/75/quality/100
-3019	ARIRANG TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/083bfe803259450b9e59de9d799ae2b6_19/version/0/width/120/height/75/quality/100
-3020	TV Globo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f3715346f3e748c088eeacef18bef34b_19/version/0/width/120/height/75/quality/100
-3024	TVCine Edition	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6ba9073760e2487488ada139d1b1f7b7_19/version/0/width/120/height/75/quality/100
-3026	Hollywood	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d3a18b81bedc48c6aaf41b64c3d570fd_19/version/0/width/120/height/75/quality/100
-3027	Cinemundo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/653fc31c29e34d62a434156b905c7cff_19/version/0/width/120/height/75/quality/100
-3028	RTP1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a1bef425c634497b9341957d36e692c3_19/version/0/width/120/height/75/quality/100
-3414	CMTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9059345359844b3ca594134c8d81ffc0_19/version/0/width/120/height/75/quality/100
-3885	DAZN 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e9ce8b8d6d2e48df8e096cd271cc982d/version/1/width/120/height/75/quality/100
-3886	DAZN 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08734341d4c9452dbe272112d5a3aaee/version/1/width/120/height/75/quality/100
-3887	DAZN 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7c03993042f64f2e80b224a52c87f6e7/version/1/width/120/height/75/quality/100
-3888	DAZN 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9f8ed7e32fb04f819475d9eb5a38d2d5/version/1/width/120/height/75/quality/100
-3889	DAZN 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/53aa4f7847834e1f8678067be941c238/version/1/width/120/height/75/quality/100
-3890	DAZN  6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2e6186034d444f83b0bf2a87836d123b/version/1/width/120/height/75/quality/100
-4862	SportTV NBA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e0b906090d974186914f5cc909c5dce6/version/0/width/120/height/75/quality/100
-5043	EuroSport 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/13130dde270143ea90c7ad709cd33cda_19/version/0/width/120/height/75/quality/100
-5583	A Bola TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/81847fc044e84e7f8f3fc9b7a1cb7d01_19/version/1/width/120/height/75/quality/100
-5585	Canal 11	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3c6048c60dc042fd84e395b33d1f049e_19/version/0/width/120/height/75/quality/100
-5609	S+	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c63940e416dd47b28de10aa3477408b0_19/version/0/width/120/height/75/quality/100
-5610	FREEDOM	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/309a6fca4d47427ca9f5c8145a0348c1/version/0/width/120/height/75/quality/100
-5678	CNN Portugal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/15dc865f76db4f7baddb09d728bd1088/version/0/width/120/height/75/quality/100
-7075	GameToon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/28aac14ad6f7411092bc81bc383cc85b_19/version/0/width/120/height/75/quality/100
-7084	RTP Açores	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7e72b63606b74facb84d4a4be512ef6b_19/version/0/width/120/height/75/quality/100
-7090	Casa e Cozinha	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e465476b8a8545488e8310c1df29e55d_19/version/0/width/120/height/75/quality/100
-7185	Panda	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/85009bcb0b8b45e7bc140a4832ca014b_19/version/0/width/120/height/75/quality/100
-7187	RTP3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d430a0822b5f469ca320bf6d6723f0ca_19/version/0/width/120/height/75/quality/100
-7188	Panda Kids	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9352c739e9b34d7b9aad308b90f521e7_19/version/0/width/120/height/75/quality/100
-7250	Sport TV 6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f31ce4c726dd4382915bfdea05a3c50f/version/0/width/120/height/75/quality/100
-7522	Disney Junior	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bbbf77ecab4440d0876889aa0d62b586/version/0/width/120/height/75/quality/100
-8005	Cartoonito	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/14dd98d3e0574155bf9e8dee613d3161_19/version/2/width/120/height/75/quality/100
-8006	Cartoon Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/23dffe336ee24fba9879f8b43eb49571_19/version/0/width/120/height/75/quality/100
-8013	GINX Esports TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25a531732c4d4ff99bab6793ad20be65_19/version/0/width/120/height/75/quality/100
-8124	iConcerts	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/655bd3fbd7764b85b6c216cf352fa320_19/version/0/width/120/height/75/quality/100
-8368	UNIFE TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2b0d86675bb8428e91c55eada3982d01_19/version/0/width/120/height/75/quality/100
-8396	CNN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/48a5c03f05264f969c71e56992a98847_19/version/1/width/120/height/75/quality/100
-8397	TVI Reality	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/8ae0590068384f8b85de367df743188e_19/version/1/width/120/height/75/quality/100
-8398	TLC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd02f77c26cb4380a1da6a2fe90a938d_19/version/1/width/120/height/75/quality/100
-8399	V+ TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e2cbe6f3c7de4a77a37e4eb878b789f7_19/version/2/width/120/height/75/quality/100
-8424	RTP Madeira	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d6249f5eef264202874dfdd5de492a9e_19/version/1/width/120/height/75/quality/100
-8426	AMC Crime	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d01e00520a5a4a2aaa1e1bf32f199dd5_19/version/1/width/120/height/75/quality/100
-8529	Dizi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/87e626cfaddd45bba7703e3df96d2c38_19/version/0/width/120/height/75/quality/100
-8598	BenficaTV Multicam 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7ba831b33ef34380b3b5b462bbf355cf/version/0/width/120/height/75/quality/100
-8599	BenficaTV Multicam 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6d713fb010f543a7a1e9848d6c791620/version/0/width/120/height/75/quality/100
-8600	BenficaTV Multicam 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/370959aa138a4805886fccabf38265e0/version/0/width/120/height/75/quality/100
-8601	BenficaTV Multicam 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b02508077c564f7883f8fc860f15b9c9/version/0/width/120/height/75/quality/100
-8606	AfroMusic 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b22774537d39440495b205b428e83a7f/version/0/width/120/height/75/quality/100
-8636	Panda Biggs	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/383f7e6f14ba48a0a69bde850dae7f50/version/0/width/120/height/75/quality/100
-8645	Nickelodeon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a5f17d29c7d4e74bea71046ffc50569/version/0/width/120/height/75/quality/100
-8646	MCM POP	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/610a1c775a4d4f89954924575c738b0e/version/0/width/120/height/75/quality/100
-8711	News Now 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7d1df4bc7fd948e3bbb57fefe3845ffb/version/0/width/120/height/75/quality/100
-8735	SIC Novelas	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd9e43272bc04420969e8e8ff0de8f8c/version/0/width/120/height/75/quality/100
-8743	Sport TV 7	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/079ac81d79f7490e844af481e5303d12/version/2/width/120/height/75/quality/100
-8775	HGTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/89768f1e6c1043279925acef9cadf5b8/version/0/width/120/height/75/quality/100
-8776	Disc ID	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5aa45346d01440dabf96211bf118c28f/version/0/width/120/height/75/quality/100
-8781	BabyTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b422dbbb9fec4df5a07b6a383d906d56/version/0/width/120/height/75/quality/100
-8782	TCV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4280bb15af7b45068bbd15138531050b/version/0/width/120/height/75/quality/100
-8783	História	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f16aac14d6d54c8bb723397b3d743f08/version/0/width/120/height/75/quality/100
+## From app
+2670	"SIC"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/807cd0cdbf314c44a0a5d9c852b2f835_19/version/0/width/120/height/75/quality/100"
+2671	"TVI"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a70ebda1d51b436d909cebf8b424b10e/version/0/width/120/height/75/quality/100"
+##2673	"História SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ffe30fdefa448ec8571115ff786ef14_19/version/0/width/120/height/75/quality/100"
+##2674	"SyFy SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/656c66e4f9784c5aacfe8a056df4e4b3_19/version/0/width/120/height/75/quality/100"
+2675	"Eurosport"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9e5ca9dad53a4dc88a3e0eb367015327_19/version/0/width/120/height/75/quality/100"
+2687	"Sport TV 1"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a524ac5886ff494086e707103e124cc7/version/0/width/120/height/75/quality/100"
+2688	"Sport TV 2"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2f08d170f2a34e6390eb533a3d86538e/version/0/width/120/height/75/quality/100"
+2689	"Sport TV 3"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bae1291a65b240abbc98c8d92f7d9718/version/0/width/120/height/75/quality/100"
+2690	"Sport TV 4"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/316b4ac356244f4f96c4c64b05946be3/version/0/width/120/height/75/quality/100"
+2691	"Sport TV 5"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/27da1d086e1e4a8a9e3003d3ef5e5f4e/version/0/width/120/height/75/quality/100"
+2692	"Fuel TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/721d0d21b99c4b239ccb9b2daf54596c_19/version/0/width/120/height/75/quality/100"
+2700	"AXN Movies"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/37500ae831f84b30822e5bd5e04fd882_19/version/0/width/120/height/75/quality/100"
+2701	"SyFy"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a0409944e5542a9b5acb0647467203a_19/version/0/width/120/height/75/quality/100"
+2706	"Fashion TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/0b7ab6b146da42d582433ebde0ee70ee_19/version/0/width/120/height/75/quality/100"
+2709	"Canção Nova"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5604f4864c104703bb3b46ec71f91114_19/version/0/width/120/height/75/quality/100"
+2710	"TV Galícia"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3af7d6ee83df46d7ab1d30a3c072e61d_19/version/0/width/120/height/75/quality/100"
+2712	"TVCine Top"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2723399dc06b4b9e8914b29467e23dab_19/version/0/width/120/height/75/quality/100"
+2713	"AXN"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a44800b441224087aea741f0bf74263c_19/version/0/width/120/height/75/quality/100"
+2715	"STAR CHANNEL"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/777adf78621046109570913715ab336c_19/version/1/width/120/height/75/quality/100"
+2717	"STAR LIFE"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5022d2f187a646d696cb57f977a0c9d1_19/version/1/width/120/height/75/quality/100"
+2723	"Trace Toca"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3178257df111483684efa8efb63e5309_19/version/0/width/120/height/75/quality/100"
+2727	"RTP Memória"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/79a94c670a9943d895f2eaca4e72780b_19/version/0/width/120/height/75/quality/100"
+2728	"RTP África"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b61b8cc6bbaf4aa6961861c2e072290e_19/version/0/width/120/height/75/quality/100"
+2736	"AR TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3cef63b6677f451d8164a908b6a1aa00_19/version/0/width/120/height/75/quality/100"
+2741	"National Geographic"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dfe23167f5144543bab68ea436dd1d15_19/version/0/width/120/height/75/quality/100"
+2742	"TV5Monde"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fd9db0bfa1e74eaeb29f0034eec69fa2_19/version/0/width/120/height/75/quality/100"
+2743	"CMUSIC"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b94207010d994916a318e040c2d22f72_19/version/0/width/120/height/75/quality/100"
+#2744	"Baby TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6e324dd3e2db4ca6998cf6a1bb73870d_19/version/0/width/120/height/75/quality/100"
+2747	"Euronews"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3346c27cb8044e5dbc17548d9610e2e8_19/version/0/width/120/height/75/quality/100"
+2748	"TVEi"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dd60890cbbbf4704a89968766f0a1c3a_19/version/0/width/120/height/75/quality/100"
+2749	"TVE 24"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a861422493ed454994f7b7a69183846b_19/version/0/width/120/height/75/quality/100"
+2750	"CNBC Europe"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/969b0d2e8fe74a0db71c223f404f0ac6_19/version/0/width/120/height/75/quality/100"
+2751	"TPA"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4e002a07acb84b02a86a19dba5ee102e_19/version/0/width/120/height/75/quality/100"
+2754	"MTV 00s"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c7f1040e19d940da8eec26928c0319de/version/0/width/120/height/75/quality/100"
+2757	"ProTV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25f5f1ac6ede4d65ab0ebf0f05908088_19/version/0/width/120/height/75/quality/100"
+2760	"Bloomberg"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/aa36677a7a9941af9e07444dd21b525d_19/version/0/width/120/height/75/quality/100"
+2765	"Nautical Channel"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ecdccfb21a5429e8d44bf2f29e4dd34_19/version/0/width/120/height/75/quality/100"
+2766	"Phoenix"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1957a8e6b0c44b66ab2e0ad91fbec763_19/version/0/width/120/height/75/quality/100"
+2768	"Porto Canal"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/16cdb28b90cb46b1aee589be8a477eff_19/version/0/width/120/height/75/quality/100"
+2769	"France 24 English"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d575daeef80442598a33b1cffa5a21a5_19/version/0/width/120/height/75/quality/100"
+2770	"France 24 FR"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e5013d5b45304e77a8911ae9d76c59ea_19/version/0/width/120/height/75/quality/100"
+2772	"RAI 1"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/30137cc9eb7f472bb80cfbea196f524d_19/version/0/width/120/height/75/quality/100"
+2779	"MCM Top"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/18855da1bce845b7b7611689f2303f8b_19/version/0/width/120/height/75/quality/100"
+2781	"DW"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/be6a088466484a99a99842ec524895f6_19/version/0/width/120/height/75/quality/100"
+2784	"AlJazeera"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/803a229c5eb146ba90f22a763c49c0c7_19/version/0/width/120/height/75/quality/100"
+2812	"Record News"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f7b7a4b51ead4f5d8028669c0287ff7c_19/version/0/width/120/height/75/quality/100"
+2825	"RTP2"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f47f5f7d4acd493891cb1225d10024e2_19/version/0/width/120/height/75/quality/100"
+2831	"TVCine Emotion"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c3a60cce67a347ecad3ae6fae99e1646_19/version/0/width/120/height/75/quality/100"
+2832	"TVCine Action"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c47a0066a7244f51beeeba84fbf46424_19/version/0/width/120/height/75/quality/100"
+2833	"AXN White"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f54c7528c31947c8be68f13748cd15b0_19/version/0/width/120/height/75/quality/100"
+2837	"E!"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/502684fe51d24e6cb81551b3b2d54ca9_19/version/0/width/120/height/75/quality/100"
+2843	"Localvisão"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c704554bdcac437490143bc61b9aec87_19/version/0/width/120/height/75/quality/100"
+2844	"24Kitchen"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/481cf968448d4b07b8c675552a16ef8a_19/version/0/width/120/height/75/quality/100"
+2845	"STAR MOVIES"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3e7474629a5b416c8deaf0919002e6df_19/version/1/width/120/height/75/quality/100"
+2846	"National Geographic Wild"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b253e37f1334406f8e93c4b1c37470de_19/version/0/width/120/height/75/quality/100"
+2847	"STAR CRIME"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25769e8d419c4ea6b63d8097352b9cae_19/version/1/width/120/height/75/quality/100"
+2849	"Sky News"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4d862190e6c549ad8f006f429ac53e52_19/version/0/width/120/height/75/quality/100"
+2852	"Benfica TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/477cd7f5a7354324b6a9a27db865708f_19/version/0/width/120/height/75/quality/100"
+2854	"TV Record"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/36bba6cd2b5746dc9a073e3e7817ec30_19/version/0/width/120/height/75/quality/100"
+2859	"RTL"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ed68fc2259e34e329d66e4974331526a_19/version/0/width/120/height/75/quality/100"
+2884	"TCV News"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cb1a4d4cc1b0472eb67ce43136c8f332_19/version/0/width/120/height/75/quality/100"
+2890	"NHK World"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf86b0c0b7714c90a27e881bbbb61ecc_19/version/0/width/120/height/75/quality/100"
+2893	"STAR COMEDY"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ea358343e7c4465c93ad1872e52ff0d6_19/version/1/width/120/height/75/quality/100"
+2897	"KBS WORLD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e23a084076eb46cabc7a2fce55e6c113_19/version/0/width/120/height/75/quality/100"
+2902	"Canal Q"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e1ebf412bd444a61afdd2d9fa1263e1a_19/version/0/width/120/height/75/quality/100"
+2903	"Fight Network"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4dcc70dcdde34d708b9ec9b1a861c8ad_19/version/0/width/120/height/75/quality/100"
+2914	"Discovery"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fa191c5ad6ba48b9bca783dafabc7498_19/version/0/width/120/height/75/quality/100"
+2915	"SIC Radical"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5a461799731d4344b277dcae381f0a89_19/version/0/width/120/height/75/quality/100"
+2925	"MTV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9108b7d984a54a43b441bb44b9a84b85_19/version/0/width/120/height/75/quality/100"
+2927	"Kuriakos TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57feab802d804da792867ebeacd0db17_19/version/0/width/120/height/75/quality/100"
+2930	"Sport TV +"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ce24543d73ab43b1b53dea9dc25d6854/version/0/width/120/height/75/quality/100"
+2931	"Mezzo Live"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/24f9fa496e70422a9830c2549dd1de0f_19/version/0/width/120/height/75/quality/100"
+2933	"Insight"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08526de0382f4a2095f6063d7a7490cd_19/version/0/width/120/height/75/quality/100"
+2934	"Docubox"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/efb948f799c2406187f8e3dcf9e29b1d_19/version/0/width/120/height/75/quality/100"
+2935	"SIC Notícias"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf33e03117ac4ece8cc3b260d4869c4a/version/0/width/120/height/75/quality/100"
+2936	"SIC Mulher"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c23aa79c4be64a78be3ea5843c079529_19/version/0/width/120/height/75/quality/100"
+2937	"SIC Caras"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/71c7fa677b894fecada52f4fdb1defb5_19/version/0/width/120/height/75/quality/100"
+2938	"SIC K"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e45f250d72334fbdb3dbe1d91c4bc751_19/version/0/width/120/height/75/quality/100"
+2993	"Travel"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9487453658fd42d9a8e515ee072328e7_19/version/0/width/120/height/75/quality/100"
+2994	"Food Network"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57a9e479ba34434a8ef249b0cd560c94_19/version/0/width/120/height/75/quality/100"
+2996	"AMC"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1b0fa6a1c5544a24bdea82e2bc9222e3_19/version/0/width/120/height/75/quality/100"
+3004	"Sporting TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/868cdc88b86b4033a6be7fd2652bd05e_19/version/0/width/120/height/75/quality/100"
+3012	"Disney Channel"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2887957962b24db6beee92d0b470a54c_19/version/0/width/120/height/75/quality/100"
+3015	"Trace"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bc50304a4b45406595c55d24d0c3ff01_19/version/0/width/120/height/75/quality/100"
+3016	"Odisseia"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/121e6e261b8749749c53c4248026ee49_19/version/0/width/120/height/75/quality/100"
+3017	"AMC Break"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/af39b08b3262477cbfd49e8a506855d4_19/version/1/width/120/height/75/quality/100"
+3019	"ARIRANG TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/083bfe803259450b9e59de9d799ae2b6_19/version/0/width/120/height/75/quality/100"
+3020	"TV Globo"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f3715346f3e748c088eeacef18bef34b_19/version/0/width/120/height/75/quality/100"
+3024	"TVCine Edition"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6ba9073760e2487488ada139d1b1f7b7_19/version/0/width/120/height/75/quality/100"
+3026	"Hollywood"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d3a18b81bedc48c6aaf41b64c3d570fd_19/version/0/width/120/height/75/quality/100"
+3027	"Cinemundo"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/653fc31c29e34d62a434156b905c7cff_19/version/0/width/120/height/75/quality/100"
+3028	"RTP1"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a1bef425c634497b9341957d36e692c3_19/version/0/width/120/height/75/quality/100"
+3414	"CMTV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9059345359844b3ca594134c8d81ffc0_19/version/0/width/120/height/75/quality/100"
+3885	"DAZN 1"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e9ce8b8d6d2e48df8e096cd271cc982d/version/1/width/120/height/75/quality/100"
+3886	"DAZN 2"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08734341d4c9452dbe272112d5a3aaee/version/1/width/120/height/75/quality/100"
+3887	"DAZN 3"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7c03993042f64f2e80b224a52c87f6e7/version/1/width/120/height/75/quality/100"
+3888	"DAZN 4"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9f8ed7e32fb04f819475d9eb5a38d2d5/version/1/width/120/height/75/quality/100"
+3889	"DAZN 5"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/53aa4f7847834e1f8678067be941c238/version/1/width/120/height/75/quality/100"
+3890	"DAZN  6"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2e6186034d444f83b0bf2a87836d123b/version/1/width/120/height/75/quality/100"
+4862	"SportTV NBA"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e0b906090d974186914f5cc909c5dce6/version/0/width/120/height/75/quality/100"
+5043	"EuroSport 2"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/13130dde270143ea90c7ad709cd33cda_19/version/0/width/120/height/75/quality/100"
+5583	"A Bola TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/81847fc044e84e7f8f3fc9b7a1cb7d01_19/version/1/width/120/height/75/quality/100"
+5585	"Canal 11"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3c6048c60dc042fd84e395b33d1f049e_19/version/0/width/120/height/75/quality/100"
+5609	"S+"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c63940e416dd47b28de10aa3477408b0_19/version/0/width/120/height/75/quality/100"
+5610	"FREEDOM"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/309a6fca4d47427ca9f5c8145a0348c1/version/0/width/120/height/75/quality/100"
+5678	"CNN Portugal"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/15dc865f76db4f7baddb09d728bd1088/version/0/width/120/height/75/quality/100"
+7075	"GameToon"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/28aac14ad6f7411092bc81bc383cc85b_19/version/0/width/120/height/75/quality/100"
+7084	"RTP Açores"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7e72b63606b74facb84d4a4be512ef6b_19/version/0/width/120/height/75/quality/100"
+7090	"Casa e Cozinha"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e465476b8a8545488e8310c1df29e55d_19/version/0/width/120/height/75/quality/100"
+7185	"Panda"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/85009bcb0b8b45e7bc140a4832ca014b_19/version/0/width/120/height/75/quality/100"
+7187	"RTP3"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d430a0822b5f469ca320bf6d6723f0ca_19/version/0/width/120/height/75/quality/100"
+7188	"Panda Kids"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9352c739e9b34d7b9aad308b90f521e7_19/version/0/width/120/height/75/quality/100"
+7250	"Sport TV 6"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f31ce4c726dd4382915bfdea05a3c50f/version/0/width/120/height/75/quality/100"
+7522	"Disney Junior"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bbbf77ecab4440d0876889aa0d62b586/version/0/width/120/height/75/quality/100"
+8005	"Cartoonito"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/14dd98d3e0574155bf9e8dee613d3161_19/version/2/width/120/height/75/quality/100"
+8006	"Cartoon Network"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/23dffe336ee24fba9879f8b43eb49571_19/version/0/width/120/height/75/quality/100"
+8013	"GINX Esports TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25a531732c4d4ff99bab6793ad20be65_19/version/0/width/120/height/75/quality/100"
+8124	"iConcerts"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/655bd3fbd7764b85b6c216cf352fa320_19/version/0/width/120/height/75/quality/100"
+8368	"UNIFE TV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2b0d86675bb8428e91c55eada3982d01_19/version/0/width/120/height/75/quality/100"
+8396	"CNN"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/48a5c03f05264f969c71e56992a98847_19/version/1/width/120/height/75/quality/100"
+8397	"TVI Reality"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/8ae0590068384f8b85de367df743188e_19/version/1/width/120/height/75/quality/100"
+8398	"TLC"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd02f77c26cb4380a1da6a2fe90a938d_19/version/1/width/120/height/75/quality/100"
+8399	"V+ TVI"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e2cbe6f3c7de4a77a37e4eb878b789f7_19/version/2/width/120/height/75/quality/100"
+8424	"RTP Madeira"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d6249f5eef264202874dfdd5de492a9e_19/version/1/width/120/height/75/quality/100"
+8426	"AMC Crime"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d01e00520a5a4a2aaa1e1bf32f199dd5_19/version/1/width/120/height/75/quality/100"
+8529	"Dizi"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/87e626cfaddd45bba7703e3df96d2c38_19/version/0/width/120/height/75/quality/100"
+8598	"BenficaTV Multicam 1"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7ba831b33ef34380b3b5b462bbf355cf/version/0/width/120/height/75/quality/100"
+8599	"BenficaTV Multicam 2"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6d713fb010f543a7a1e9848d6c791620/version/0/width/120/height/75/quality/100"
+8600	"BenficaTV Multicam 3"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/370959aa138a4805886fccabf38265e0/version/0/width/120/height/75/quality/100"
+8601	"BenficaTV Multicam 4"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b02508077c564f7883f8fc860f15b9c9/version/0/width/120/height/75/quality/100"
+8606	"AfroMusic"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b22774537d39440495b205b428e83a7f/version/0/width/120/height/75/quality/100"
+8636	"Panda Biggs"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/383f7e6f14ba48a0a69bde850dae7f50/version/0/width/120/height/75/quality/100"
+8645	"Nickelodeon"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a5f17d29c7d4e74bea71046ffc50569/version/0/width/120/height/75/quality/100"
+8646	"MCM POP"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/610a1c775a4d4f89954924575c738b0e/version/0/width/120/height/75/quality/100"
+8711	"News Now"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7d1df4bc7fd948e3bbb57fefe3845ffb/version/0/width/120/height/75/quality/100"
+8735	"SIC Novelas"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd9e43272bc04420969e8e8ff0de8f8c/version/0/width/120/height/75/quality/100"
+8743	"Sport TV 7"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/079ac81d79f7490e844af481e5303d12/version/2/width/120/height/75/quality/100"
+8775	"HGTV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/89768f1e6c1043279925acef9cadf5b8/version/0/width/120/height/75/quality/100"
+8776	"Disc ID"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5aa45346d01440dabf96211bf118c28f/version/0/width/120/height/75/quality/100"
+8781	"BabyTV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b422dbbb9fec4df5a07b6a383d906d56/version/0/width/120/height/75/quality/100"
+8782	"TCV"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4280bb15af7b45068bbd15138531050b/version/0/width/120/height/75/quality/100"
+8783	"História"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f16aac14d6d54c8bb723397b3d743f08/version/0/width/120/height/75/quality/100"
+#### Manual map, May contain errors. Commented out SD/HD dupes
+##2815	"180 SD"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2814	"180"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2707	"24Kitchen SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/481cf968448d4b07b8c675552a16ef8a_19/version/0/width/120/height/75/quality/100"
+##5584	"A Bola TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/81847fc044e84e7f8f3fc9b7a1cb7d01_19/version/1/width/120/height/75/quality/100"
+##2704	"AMC Break SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/af39b08b3262477cbfd49e8a506855d4_19/version/1/width/120/height/75/quality/100"
+##2997	"AMC SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1b0fa6a1c5544a24bdea82e2bc9222e3_19/version/0/width/120/height/75/quality/100"
+##2752	"AXN Movies SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/37500ae831f84b30822e5bd5e04fd882_19/version/0/width/120/height/75/quality/100"
+##2698	"AXN SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a44800b441224087aea741f0bf74263c_19/version/0/width/120/height/75/quality/100"
+##2753	"AXN White SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f54c7528c31947c8be68f13748cd15b0_19/version/0/width/120/height/75/quality/100"
+##2880	"AfroMusic  SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b22774537d39440495b205b428e83a7f/version/0/width/120/height/75/quality/100"
+2746	"BBC World"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##3405	"Benfica TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/477cd7f5a7354324b6a9a27db865708f_19/version/0/width/120/height/75/quality/100"
+2775	"Blue Hustler"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##3014	"CMTV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9059345359844b3ca594134c8d81ffc0_19/version/0/width/120/height/75/quality/100"
+##2786	"CNN Portugal SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/15dc865f76db4f7baddb09d728bd1088/version/0/width/120/height/75/quality/100"
+##2782	"CNN SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/48a5c03f05264f969c71e56992a98847_19/version/1/width/120/height/75/quality/100"
+##5586	"Canal 11 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3c6048c60dc042fd84e395b33d1f049e_19/version/0/width/120/height/75/quality/100"
+##2901	"Canal Q SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e1ebf412bd444a61afdd2d9fa1263e1a_19/version/0/width/120/height/75/quality/100"
+##2694	"Cartoon Network SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/23dffe336ee24fba9879f8b43eb49571_19/version/0/width/120/height/75/quality/100"
+##3021	"Cartoonito SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/14dd98d3e0574155bf9e8dee613d3161_19/version/2/width/120/height/75/quality/100"
+##7089	"Casa e Cozinha SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e465476b8a8545488e8310c1df29e55d_19/version/0/width/120/height/75/quality/100"
+2857	"Caça e Pesca"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##4861	"CaçaVision SD"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2725	"CaçaVision"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2885	"Cinemundo SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/653fc31c29e34d62a434156b905c7cff_19/version/0/width/120/height/75/quality/100"
+2785	"CubaVision"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##3888	"DAZN 4 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9f8ed7e32fb04f819475d9eb5a38d2d5/version/1/width/120/height/75/quality/100"
+##3889	"DAZN 5 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/53aa4f7847834e1f8678067be941c238/version/1/width/120/height/75/quality/100"
+##2777	"Discovery SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fa191c5ad6ba48b9bca783dafabc7498_19/version/0/width/120/height/75/quality/100"
+##2693	"Disney Junior SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bbbf77ecab4440d0876889aa0d62b586/version/0/width/120/height/75/quality/100"
+2883	"DogTv"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2755	"E! SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/502684fe51d24e6cb81551b3b2d54ca9_19/version/0/width/120/height/75/quality/100"
+##3415	"EuroChannel SD"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+3416	"EuroChannel"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2756	"EuroSport 2 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/13130dde270143ea90c7ad709cd33cda_19/version/0/width/120/height/75/quality/100"
+2998	"Euronews EN"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3346c27cb8044e5dbc17548d9610e2e8_19/version/0/width/120/height/75/quality/100"
+##2672	"Eurosport SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9e5ca9dad53a4dc88a3e0eb367015327_19/version/0/width/120/height/75/quality/100"
+##2740	"Fashion TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/0b7ab6b146da42d582433ebde0ee70ee_19/version/0/width/120/height/75/quality/100"
+2720	"FightBox"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2792	"Food Network SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57a9e479ba34434a8ef249b0cd560c94_19/version/0/width/120/height/75/quality/100"
+##2732	"Fuel TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/721d0d21b99c4b239ccb9b2daf54596c_19/version/0/width/120/height/75/quality/100"
+2924	"FunBox"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2791	"GINX Esports TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25a531732c4d4ff99bab6793ad20be65_19/version/0/width/120/height/75/quality/100"
+##2696	"Hollywood SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d3a18b81bedc48c6aaf41b64c3d570fd_19/version/0/width/120/height/75/quality/100"
+2922	"Hot Man"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2923	"Hot Taboo"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2802	"Hot offset-1h"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2829	"Hot"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2783	"Hustler"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+3412	"Insight Ultra"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2842	"Localvisão SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c704554bdcac437490143bc61b9aec87_19/version/0/width/120/height/75/quality/100"
+2762	"Luxe TV"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2856	"M6"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2886	"MCM Top SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/18855da1bce845b7b7611689f2303f8b_19/version/0/width/120/height/75/quality/100"
+##3025	"MTV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9108b7d984a54a43b441bb44b9a84b85_19/version/0/width/120/height/75/quality/100"
+2761	"Mezzo"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2708	"My Zen TV"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2745	"National Geographic SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dfe23167f5144543bab68ea436dd1d15_19/version/0/width/120/height/75/quality/100"
+##2702	"National Geographic Wild SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b253e37f1334406f8e93c4b1c37470de_19/version/0/width/120/height/75/quality/100"
+##6008	"Nickelodeon SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a5f17d29c7d4e74bea71046ffc50569/version/0/width/120/height/75/quality/100"
+##2703	"Odisseia SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/121e6e261b8749749c53c4248026ee49_19/version/0/width/120/height/75/quality/100"
+8518	"OneToro"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2809	"Panda Biggs SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/383f7e6f14ba48a0a69bde850dae7f50/version/0/width/120/height/75/quality/100"
+##2714	"Panda SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/85009bcb0b8b45e7bc140a4832ca014b_19/version/0/width/120/height/75/quality/100"
+##2806	"PentHouse Gold SD"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2805	"PentHouse Gold"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2804	"PentHouse SD"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2803	"PentHouse"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##8425	"PlayBoy SD"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2767	"PlayBoy"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2904	"Porto Canal SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/16cdb28b90cb46b1aee589be8a477eff_19/version/0/width/120/height/75/quality/100"
+2773	"RAI News"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2882	"RTP Açores SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7e72b63606b74facb84d4a4be512ef6b_19/version/0/width/120/height/75/quality/100"
+##2877	"RTP Madeira SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d6249f5eef264202874dfdd5de492a9e_19/version/1/width/120/height/75/quality/100"
+##3406	"RTP1 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a1bef425c634497b9341957d36e692c3_19/version/0/width/120/height/75/quality/100"
+##3407	"RTP2 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f47f5f7d4acd493891cb1225d10024e2_19/version/0/width/120/height/75/quality/100"
+##2726	"RTP3 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d430a0822b5f469ca320bf6d6723f0ca_19/version/0/width/120/height/75/quality/100"
+2711	"SET Asia"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2794	"SET Max"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##2900	"SIC Caras SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/71c7fa677b894fecada52f4fdb1defb5_19/version/0/width/120/height/75/quality/100"
+##2913	"SIC K SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e45f250d72334fbdb3dbe1d91c4bc751_19/version/0/width/120/height/75/quality/100"
+##2733	"SIC Mulher SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c23aa79c4be64a78be3ea5843c079529_19/version/0/width/120/height/75/quality/100"
+##2686	"SIC Notícias SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf33e03117ac4ece8cc3b260d4869c4a/version/0/width/120/height/75/quality/100"
+##2734	"SIC Radical SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5a461799731d4344b277dcae381f0a89_19/version/0/width/120/height/75/quality/100"
+##3408	"SIC SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/807cd0cdbf314c44a0a5d9c852b2f835_19/version/0/width/120/height/75/quality/100"
+##2697	"STAR CHANNEL SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/777adf78621046109570913715ab336c_19/version/1/width/120/height/75/quality/100"
+##2699	"STAR COMEDY SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ea358343e7c4465c93ad1872e52ff0d6_19/version/1/width/120/height/75/quality/100"
+##2737	"STAR CRIME SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25769e8d419c4ea6b63d8097352b9cae_19/version/1/width/120/height/75/quality/100"
+##2678	"STAR LIFE SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5022d2f187a646d696cb57f977a0c9d1_19/version/1/width/120/height/75/quality/100"
+##2677	"STAR MOVIES HD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3e7474629a5b416c8deaf0919002e6df_19/version/1/width/120/height/75/quality/100"
+##2929	"Sport TV + SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ce24543d73ab43b1b53dea9dc25d6854/version/0/width/120/height/75/quality/100"
+##2729	"Sport TV 1 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a524ac5886ff494086e707103e124cc7/version/0/width/120/height/75/quality/100"
+##2730	"Sport TV 2 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2f08d170f2a34e6390eb533a3d86538e/version/0/width/120/height/75/quality/100"
+##2731	"Sport TV 3 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bae1291a65b240abbc98c8d92f7d9718/version/0/width/120/height/75/quality/100"
+##2811	"Sport TV 4 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/316b4ac356244f4f96c4c64b05946be3/version/0/width/120/height/75/quality/100"
+##2719	"Sport TV 5 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/27da1d086e1e4a8a9e3003d3ef5e5f4e/version/0/width/120/height/75/quality/100"
+##7251	"Sport TV 6 SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f31ce4c726dd4382915bfdea05a3c50f/version/0/width/120/height/75/quality/100"
+##3003	"Sporting TV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/868cdc88b86b4033a6be7fd2652bd05e_19/version/0/width/120/height/75/quality/100"
+3022	"Stingray Classica"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2879	"Stingray DJazz"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2940	"Stingray Naturescape"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2860	"Super RTL"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+##3002	"TCV SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4280bb15af7b45068bbd15138531050b/version/0/width/120/height/75/quality/100"
+##2705	"TLC SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd02f77c26cb4380a1da6a2fe90a938d_19/version/1/width/120/height/75/quality/100"
+##2932	"TV Globo SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f3715346f3e748c088eeacef18bef34b_19/version/0/width/120/height/75/quality/100"
+##2776	"TV Record SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/36bba6cd2b5746dc9a073e3e7817ec30_19/version/0/width/120/height/75/quality/100"
+##2739	"TVCine Action SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c47a0066a7244f51beeeba84fbf46424_19/version/0/width/120/height/75/quality/100"
+##2738	"TVCine Edition SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6ba9073760e2487488ada139d1b1f7b7_19/version/0/width/120/height/75/quality/100"
+##3023	"TVCine Emotion SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c3a60cce67a347ecad3ae6fae99e1646_19/version/0/width/120/height/75/quality/100"
+##2695	"TVCine Top SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2723399dc06b4b9e8914b29467e23dab_19/version/0/width/120/height/75/quality/100"
+##3409	"TVI SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a70ebda1d51b436d909cebf8b424b10e/version/0/width/120/height/75/quality/100"
+##2764	"Trace SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bc50304a4b45406595c55d24d0c3ff01_19/version/0/width/120/height/75/quality/100"
+##2758	"Travel SD"	"https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9487453658fd42d9a8e515ee072328e7_19/version/0/width/120/height/75/quality/100"
+2807	"Utsav Gold"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2808	"Utsav Plus"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png
+2861	"Vox"	https://logovector.net/wp-content/uploads/2013/04/342506-vodafone-13-logo.png

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -284,7 +284,7 @@ sub get_epg
             my $channelId = make_channelid( $channelInfo->{$channel}->{name} );
             my %ch = (
                 'id' => $channelId,
-                'icon' => [ { src =>  $channelInfo->{$channel}->{icon} } ],
+                'icon' => [ { src =>  unquote($channelInfo->{$channel}->{icon}) } ],
             );
             # multiple display-names are ok and may be useful to match other tools lists
             my @displayname = ( [  sanitizeUTF8( $channelInfo->{$channel}->{name} ), 'pt' ] ,
@@ -323,79 +323,35 @@ sub get_epg
 
                     $prog{start} = $dtstart;
                     $prog{stop} = $dtend;
-
                     $prog{channel} = $channelId;
-                    $prog{title} = [ [ sanitizeUTF8($programme->{name}), 'pt' ] ];
-                    $prog{desc} = [ [ sanitizeUTF8($programme->{description}), 'pt' ] ]                     if ($programme->{description});
-
-                    if ($programme->{metas}{'display duration'}{value}) {
-                        my $duration_str = $programme->{metas}{'display duration'}{value};
-                        my @duration_items = split(/[PTHMS]/,$duration_str);
-                        $prog{length} = $duration_items[2]*3600+$duration_items[3]*60+$duration_items[4] if scalar @duration_items;
-                    }
-                    
-                    # fetch programme images in 16:9
-                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/width/360/height/640/quality/95" } ]  if ($programme->{images}[0]{url} && $programme->{images}[0]{imageTypeName} eq "ca" );
-                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/width/640/height/360/quality/95" } ]  if ($programme->{images}[0]{url} && $programme->{images}[0]{imageTypeName} eq "cc");
-
-                    if ( $programme->{tags}{genre} ) {
-                        my @category = map { [ sanitizeUTF8($_->{value}) , 'pt' ] } @{$programme->{tags}{genre}{objects}};
-                        $prog{category} = \@category;
-                    }
-                    $prog{country} = [ [ sanitizeUTF8($programme->{tags}{'country of production'}{objects}[0]{value}), 'pt' ] ] if $programme->{tags}{'country of production'};
-
-                    if ($programme->{tags}{'parental Rating'}) {
-                        my $rating;
-                        if ($programme->{tags}{'parental Rating'}{objects}[0]{value} == 0) {
-                            $rating = [ [ "All Ages", 'Portuguese Movie Rating' ] ];
-                        } else {
-                            $rating = [ [ "M/".$programme->{tags}{'parental Rating'}{objects}[0]{value}, 'Portuguese Movie Rating' ] ];
-                        }
-                        $prog{rating} = $rating if $rating; 
-                    }
-
-                    my @images;
-                    for my $image (@{$programme->{images}}) {
-                        next if !$image->{url};
-
-                        my $type = "";
-                        my $orient = "";
-                        my $size = 3;
-                        my $system = "vodafone";
-                        my $width = 640;
-                        my $height = 360;
-
-                        if ($image->{imageTypeName} eq "cc") {
-                            $orient = "L";
-                            $type = "still";
-                        } elsif ($image->{imageTypeName} eq "ca") {
-                            $orient = "P";
-                            $type = "poster";
-                            $width = 360;
-                            $height = 640;
-                        } elsif ($image->{imageTypeName} eq "bg") {
-                            $orient = "L";
-                            $type = "backdrop";
-                        }
-
-                        my $url = $image->{url};
-                        push @images, [ $image->{url}."/width/".$width."/height/".$height."/quality/95", { type => $type, size => $size, orient => $orient, system => $system } ];
-                    }
-                    $prog{image} = \@images if scalar @images;
-
-                    $prog{date} = sanitizeUTF8($programme->{metas}{year}{value}) if $programme->{metas}{year}{value};
-
-                    if ( $programme->{tags}{actors} ) {
-                        my @actors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{actors}{objects}};
-                        $prog{credits}{actor} = \@actors;                        
-                    }
-
-                    if ( $programme->{tags}{director} ) {
-                        my @directors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{director}{objects}} ;
-                        $prog{credits}{director} = \@directors;
-                    }
-
+                    $prog{title} = get_title($programme);
+                    $prog{desc} = get_desc($programme); 
+                    $prog{date} = get_date($programme);
                     $prog{'episode-num'} = make_episode_num($programme);
+
+                    my $length = get_length($programme);
+                    $prog{length} = $length if $length;
+
+                    my $icon = get_icon($programme);
+                    $prog{icon} = $icon if $icon;
+
+                    my $category = get_category($programme);
+                    $prog{category} = $category if $category;
+
+                    my $country = get_country($programme);
+                    $prog{country} = $country if $country;
+
+                    my $rating = get_rating($programme);
+                    $prog{rating} = $rating if $rating;
+
+                    my $image = get_images($programme);
+                    $prog{image} = $image if $image;
+
+                    my $actors = get_actors($programme);
+                    $prog{credits}{actor} = $actors if $actors;
+
+                    my $directors = get_directors($programme);
+                    $prog{credits}{director} = $directors if $directors;
 
                     # We can get the same programme for two different days if it goes past midnight.
                     # Lets remove duplicates here.
@@ -524,4 +480,118 @@ sub make_channelid
     $id = unidecode($id);
     $id .= '.tv.vodafone.pt'; # append domain part
     return( $id );
+}
+
+sub unquote {
+    my ($str) = @_;
+    $str =~ s/^"//;
+    $str =~ s/"$//;
+    return $str;
+}
+
+sub get_title {
+    my ($programme) = @_;
+    return [ [ sanitizeUTF8($programme->{name}), 'pt' ] ];
+}
+
+sub get_desc {
+    my ($programme) = @_;
+    return [ [ sanitizeUTF8($programme->{description}), 'pt' ] ] if ($programme->{description});
+}
+
+sub get_length {
+    my ($programme) = @_;
+    if ($programme->{metas}{'display duration'}{value}) {
+        my $duration_str = $programme->{metas}{'display duration'}{value};
+        my @duration_items = split(/[PTHMS]/, $duration_str);
+        return $duration_items[2] * 3600 + $duration_items[3] * 60 + $duration_items[4] if scalar @duration_items;
+    }
+}
+
+sub get_icon {
+    my ($programme) = @_;
+    if ($programme->{images}[0]{url} && $programme->{images}[0]{imageTypeName} eq "ca") {
+        return [ { src => $programme->{images}[0]{url} . "/width/360/height/640/quality/95" } ];
+    }
+    if ($programme->{images}[0]{url} && $programme->{images}[0]{imageTypeName} eq "cc") {
+        return [ { src => $programme->{images}[0]{url} . "/width/640/height/360/quality/95" } ];
+    }
+}
+
+sub get_category {
+    my ($programme) = @_;
+    if ($programme->{tags}{genre}) {
+        my @category = map { [ sanitizeUTF8($_->{value}), 'pt' ] } @{$programme->{tags}{genre}{objects}};
+        return \@category;
+    }
+}
+
+sub get_country {
+    my ($programme) = @_;
+    return [ [ sanitizeUTF8($programme->{tags}{'country of production'}{objects}[0]{value}), 'pt' ] ] if $programme->{tags}{'country of production'};
+}
+
+sub get_rating {
+    my ($programme) = @_;
+    if ($programme->{tags}{'parental Rating'}) {
+        my $rating;
+        if ($programme->{tags}{'parental Rating'}{objects}[0]{value} == 0) {
+            $rating = [ [ "All Ages", 'Portuguese Movie Rating' ] ];
+        } else {
+            $rating = [ [ "M/" . $programme->{tags}{'parental Rating'}{objects}[0]{value}, 'Portuguese Movie Rating' ] ];
+        }
+        return $rating if $rating;
+    }
+}
+
+sub get_images {
+    my ($programme) = @_;
+    my @images;
+    for my $image (@{$programme->{images}}) {
+        next if !$image->{url};
+
+        my $type = "";
+        my $orient = "";
+        my $size = 3;
+        my $system = "vodafone";
+        my $width = 640;
+        my $height = 360;
+
+        if ($image->{imageTypeName} eq "cc") {
+            $orient = "L";
+            $type = "still";
+        } elsif ($image->{imageTypeName} eq "ca") {
+            $orient = "P";
+            $type = "poster";
+            $width = 360;
+            $height = 640;
+        } elsif ($image->{imageTypeName} eq "bg") {
+            $orient = "L";
+            $type = "backdrop";
+        }
+
+        push @images, [ $image->{url} . "/width/" . $width . "/height/" . $height . "/quality/95", { type => $type, size => $size, orient => $orient, system => $system } ];
+    }
+    return \@images if scalar @images;
+}
+
+sub get_date {
+    my ($programme) = @_;
+    return sanitizeUTF8($programme->{metas}{year}{value}) if $programme->{metas}{year}{value};
+}
+
+sub get_actors {
+    my ($programme) = @_;
+    if ($programme->{tags}{actors}) {
+        my @actors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{actors}{objects}};
+        return \@actors;
+    }
+}
+
+sub get_directors {
+    my ($programme) = @_;
+    if ($programme->{tags}{director}) {
+        my @directors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{director}{objects}};
+        return \@directors;
+    }
 }

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -118,6 +118,10 @@ use URI::Escape qw/ uri_escape /;
 use URI::Encode qw/ uri_encode uri_decode/;
 # use Data::Dump qw/pp/; # uncomment to debug
 
+# needed to find the channel.list location
+use File::Basename;
+my $dirname = dirname(__FILE__);
+
 my $maxdays = 1+6; # data source is limited to 7 days (including today)
 
 my $grabber_name = 'tv_grab_pt_vodafone';
@@ -127,7 +131,7 @@ my $json_baseurl = 'https://cdn.pt.vtv.vodafone.com/epg/';
 
 # Generate with:
 # jq -r '.channels[]|(.epgId,.title,.logo.color.uri)' channel.list.new | sed 'N;N; s/\n/\t/g' | sort > channel.list
-my $input_file = 'channel.list';
+my $input_file = $dirname . '/channel.list';
 
 my $ua = LWP::UserAgent->new(ssl_opts => {
     SSL_cipher_list => 'DEFAULT:!DH',

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -221,7 +221,7 @@ sub list_channels
     my $root=XML::LibXML::Element->new( 'tv' );
     $output->setDocumentElement( $root );
 
-    foreach my $key ( keys %$channellist ) {
+    foreach my $key ( sort keys %$channellist ) {
         my $channel=$channellist->{$key};
         my $sigla=$key;
         my $name=$channel->{name};
@@ -337,7 +337,7 @@ sub get_epg
                     }
                     
                     # fetch programme images in 16:9
-                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/width/854/height/480/quality/95" } ]  if ($programme->{images}[0]{url});
+                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/height/480/quality/95" } ]  if ($programme->{images}[0]{url});
 
                     if ( $programme->{tags}{genre} ) {
                         my @category = map { [ sanitizeUTF8($_->{value}) , 'pt' ] } @{$programme->{tags}{genre}{objects}};

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -113,9 +113,10 @@ use XMLTV::Configure::Writer;
 use XMLTV::Get_nice qw/get_nice/;
 use XMLTV::Options qw/ParseOptions/;
 use JSON;
+use Text::Unidecode;
 use URI::Escape qw/ uri_escape /;
 use URI::Encode qw/ uri_encode uri_decode/;
-use Data::Dump qw/pp/; # uncomment to debug
+# use Data::Dump qw/pp/; # uncomment to debug
 
 my $maxdays = 1+6; # data source is limited to 7 days (including today)
 
@@ -123,6 +124,10 @@ my $grabber_name = 'tv_grab_pt_vodafone';
 my $grabber_version = '3.00';
 
 my $json_baseurl = 'https://cdn.pt.vtv.vodafone.com/epg/';
+
+# Generate with:
+# jq -r '.channels[]|(.epgId,.title,.logo.color.uri)' channel.list.new | sed 'N;N; s/\n/\t/g' | sort > channel.list
+my $input_file = 'channel.list';
 
 my $ua = LWP::UserAgent->new(ssl_opts => {
     SSL_cipher_list => 'DEFAULT:!DH',
@@ -144,10 +149,6 @@ my( $opt, $conf ) = ParseOptions( {
 # limit to maxdays in the future
 if ($opt->{offset} + $opt->{days} > $maxdays) {
     $opt->{days} = $maxdays - $opt->{offset};
-}
-
-if ($opt->{days} < 1) {
-    $opt->{days} = 0;
 }
 
 # Get the actual data and print it to stdout.
@@ -176,7 +177,7 @@ $writer->start({
     'source-info-url' => $json_baseurl,
 });
 
-if ($opt->{days} > 0) {
+if ( ! undef $opt->{days} ) {
     if( !$opt->{quiet} ) {
         print( STDERR "fetching data\n" );
     }
@@ -242,15 +243,15 @@ sub _read_channel_data
 {
     my $channel_list = {};
     my $c = 0;
-    while (my $channel_string = <DATA>) {
+    open( my $input_fh, "<", $input_file ) || die "Can't open $input_file: $!";
+    while (my $channel_string = <$input_fh>) {
         chomp($channel_string);
         next if not length $channel_string;
         my @items = split("\t",$channel_string);
         $channel_list->{ $items[0] } = { 
-            name => $items[1],
+            name => decode('UTF-8', $items[1]),
             icon => $items[2]
-        } ;
-        last;
+        };
     }
 
     return $channel_list
@@ -271,7 +272,7 @@ sub get_epg
 
     my $channelInfo = _read_channel_data();
 
-    for my $day (0..$nr_days) {
+    for my $day ( 0 .. $nr_days ) {
 
         $curDate->add(days => $day);
 
@@ -284,7 +285,7 @@ sub get_epg
             );
             # multiple display-names are ok and may be useful to match other tools lists
             my @displayname = ( [  sanitizeUTF8( $channelInfo->{$channel}->{name} ), 'pt' ] ,
-                                [  sanitizeUTF8( $channelId ),   'pt' ] );
+                                [  sanitizeUTF8( $channelId ), 'pt' ] );
 
             push @{ $ch{'display-name'} }, @displayname ;
 
@@ -311,9 +312,6 @@ sub get_epg
 
                 my $data = $epgSource->{result}->{objects};
 
-                #pp $data;
-                #exit;
-
                 PROGRAMME:
                 for my $programme ( @{ $data }) {
                     my %prog;
@@ -333,18 +331,21 @@ sub get_epg
                         $prog{length} = $duration_items[2]*3600+$duration_items[3]*60+$duration_items[4] if scalar @duration_items;
                     }
                     
-                    $prog{icon} = [ { src => $programme->{images}[0]{url} } ]                                        if ($programme->{images}[0]{url});
+                    $prog{icon} = [ { src => $programme->{images}[0]{url} } ]  if ($programme->{images}[0]{url});
 
                     if ( $programme->{tags}{genre} ) {
                         my @category = map { [ sanitizeUTF8($_->{value}) , 'pt' ] } @{$programme->{tags}{genre}{objects}};
                         $prog{category} = \@category;
                     }
                     $prog{country} = [ [ sanitizeUTF8($programme->{tags}{'country of production'}{objects}[0]{value}), 'pt' ] ] if $programme->{tags}{'country of production'};
-                    $prog{date} = sanitizeUTF8($programme->{metas}{year}{value}) if $programme->{tags}{year};
+
+                    $prog{date} = sanitizeUTF8($programme->{metas}{year}{value}) if $programme->{metas}{year}{value};
+
                     if ( $programme->{tags}{actors} ) {
                         my @actors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{actors}{objects}};
                         $prog{credits}{actor} = \@actors;                        
                     }
+
                     if ( $programme->{tags}{director} ) {
                         my @directors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{director}{objects}} ;
                         $prog{credits}{director} = \@directors;
@@ -371,6 +372,8 @@ sub get_epg
     for my $ch (keys %xmlchannels) {
         $writer->write_programme($_) for values %{ $xmlprogs{$ch} };
     }
+
+    $is_success=1;
 }
 
 sub sanitizeUTF8 {
@@ -463,7 +466,6 @@ sub make_dates
     my $dtend = DateTime->from_epoch(epoch =>$endTime);
 
     # dates look like GMT, we tried UTC but in summer time they fail
-    #return ($dtstart->strftime( '%Y%m%d%H%M%S %z' ), $dtend->strftime( '%Y%m%d%H%M%S %z' ));
     return ($dtstart->strftime( '%Y%m%d%H%M%S +0000' ), $dtend->strftime( '%Y%m%d%H%M%S +0000' ), $starts_today);
 
 }
@@ -471,159 +473,14 @@ sub make_dates
 sub make_channelid
 {
     my( $id ) = @_;
+    $id = decode 'UTF-8', $id;
     $id = lc( $id );      # turn into lowercase
     $id =~ s/\s+//g;      # remove whitespace
     $id =~ s/&//g;        # remove ampersand
     $id =~ s/!//g;        # remove !
     $id =~ s/\x{e7}/c/g;  # turn c-cecille into plain c
     $id =~ s/\+/-plus/g;  # turn + into -plus
+    $id = unidecode($id);
     $id .= '.tv.vodafone.pt'; # append domain part
     return( $id );
 }
-
-
-# Generate with:
-# jq -r '.channels[]|(.epgId,.title,.logo.color.uri)' channel.list.new | sed 'N;N; s/\n/\t/g' | sort > channel.list
-__DATA__
-2670	SIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/807cd0cdbf314c44a0a5d9c852b2f835_19/version/0/width/120/height/75/quality/100
-2671	TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a70ebda1d51b436d909cebf8b424b10e/version/0/width/120/height/75/quality/100
-2673	História SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ffe30fdefa448ec8571115ff786ef14_19/version/0/width/120/height/75/quality/100
-2674	SyFy SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/656c66e4f9784c5aacfe8a056df4e4b3_19/version/0/width/120/height/75/quality/100
-2675	Eurosport	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9e5ca9dad53a4dc88a3e0eb367015327_19/version/0/width/120/height/75/quality/100
-2687	Sport TV 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a524ac5886ff494086e707103e124cc7/version/0/width/120/height/75/quality/100
-2688	Sport TV 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2f08d170f2a34e6390eb533a3d86538e/version/0/width/120/height/75/quality/100
-2689	Sport TV 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bae1291a65b240abbc98c8d92f7d9718/version/0/width/120/height/75/quality/100
-2690	Sport TV 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/316b4ac356244f4f96c4c64b05946be3/version/0/width/120/height/75/quality/100
-2691	Sport TV 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/27da1d086e1e4a8a9e3003d3ef5e5f4e/version/0/width/120/height/75/quality/100
-2692	Fuel TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/721d0d21b99c4b239ccb9b2daf54596c_19/version/0/width/120/height/75/quality/100
-2700	AXN Movies	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/37500ae831f84b30822e5bd5e04fd882_19/version/0/width/120/height/75/quality/100
-2701	SyFy	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a0409944e5542a9b5acb0647467203a_19/version/0/width/120/height/75/quality/100
-2706	Fashion TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/0b7ab6b146da42d582433ebde0ee70ee_19/version/0/width/120/height/75/quality/100
-2709	Canção Nova	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5604f4864c104703bb3b46ec71f91114_19/version/0/width/120/height/75/quality/100
-2710	TV Galícia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3af7d6ee83df46d7ab1d30a3c072e61d_19/version/0/width/120/height/75/quality/100
-2712	TVCine Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2723399dc06b4b9e8914b29467e23dab_19/version/0/width/120/height/75/quality/100
-2713	AXN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a44800b441224087aea741f0bf74263c_19/version/0/width/120/height/75/quality/100
-2715	STAR CHANNEL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/777adf78621046109570913715ab336c_19/version/1/width/120/height/75/quality/100
-2717	STAR LIFE	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5022d2f187a646d696cb57f977a0c9d1_19/version/1/width/120/height/75/quality/100
-2723	Trace Toca	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3178257df111483684efa8efb63e5309_19/version/0/width/120/height/75/quality/100
-2727	RTP Memória	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/79a94c670a9943d895f2eaca4e72780b_19/version/0/width/120/height/75/quality/100
-2728	RTP África	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b61b8cc6bbaf4aa6961861c2e072290e_19/version/0/width/120/height/75/quality/100
-2736	AR TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3cef63b6677f451d8164a908b6a1aa00_19/version/0/width/120/height/75/quality/100
-2741	National Geographic	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dfe23167f5144543bab68ea436dd1d15_19/version/0/width/120/height/75/quality/100
-2742	TV5Monde	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fd9db0bfa1e74eaeb29f0034eec69fa2_19/version/0/width/120/height/75/quality/100
-2743	CMUSIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b94207010d994916a318e040c2d22f72_19/version/0/width/120/height/75/quality/100
-2744	Baby TV SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6e324dd3e2db4ca6998cf6a1bb73870d_19/version/0/width/120/height/75/quality/100
-2747	Euronews	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3346c27cb8044e5dbc17548d9610e2e8_19/version/0/width/120/height/75/quality/100
-2748	TVEi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dd60890cbbbf4704a89968766f0a1c3a_19/version/0/width/120/height/75/quality/100
-2749	TVE 24	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a861422493ed454994f7b7a69183846b_19/version/0/width/120/height/75/quality/100
-2750	CNBC Europe	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/969b0d2e8fe74a0db71c223f404f0ac6_19/version/0/width/120/height/75/quality/100
-2751	TPA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4e002a07acb84b02a86a19dba5ee102e_19/version/0/width/120/height/75/quality/100
-2754	MTV 00s 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c7f1040e19d940da8eec26928c0319de/version/0/width/120/height/75/quality/100
-2757	ProTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25f5f1ac6ede4d65ab0ebf0f05908088_19/version/0/width/120/height/75/quality/100
-2760	Bloomberg	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/aa36677a7a9941af9e07444dd21b525d_19/version/0/width/120/height/75/quality/100
-2765	Nautical Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ecdccfb21a5429e8d44bf2f29e4dd34_19/version/0/width/120/height/75/quality/100
-2766	Phoenix	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1957a8e6b0c44b66ab2e0ad91fbec763_19/version/0/width/120/height/75/quality/100
-2768	Porto Canal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/16cdb28b90cb46b1aee589be8a477eff_19/version/0/width/120/height/75/quality/100
-2769	France 24 English	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d575daeef80442598a33b1cffa5a21a5_19/version/0/width/120/height/75/quality/100
-2770	France 24 FR	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e5013d5b45304e77a8911ae9d76c59ea_19/version/0/width/120/height/75/quality/100
-2772	RAI 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/30137cc9eb7f472bb80cfbea196f524d_19/version/0/width/120/height/75/quality/100
-2779	MCM Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/18855da1bce845b7b7611689f2303f8b_19/version/0/width/120/height/75/quality/100
-2781	DW	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/be6a088466484a99a99842ec524895f6_19/version/0/width/120/height/75/quality/100
-2784	AlJazeera	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/803a229c5eb146ba90f22a763c49c0c7_19/version/0/width/120/height/75/quality/100
-2812	Record News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f7b7a4b51ead4f5d8028669c0287ff7c_19/version/0/width/120/height/75/quality/100
-2825	RTP2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f47f5f7d4acd493891cb1225d10024e2_19/version/0/width/120/height/75/quality/100
-2831	TVCine Emotion	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c3a60cce67a347ecad3ae6fae99e1646_19/version/0/width/120/height/75/quality/100
-2832	TVCine Action	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c47a0066a7244f51beeeba84fbf46424_19/version/0/width/120/height/75/quality/100
-2833	AXN White	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f54c7528c31947c8be68f13748cd15b0_19/version/0/width/120/height/75/quality/100
-2837	E!	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/502684fe51d24e6cb81551b3b2d54ca9_19/version/0/width/120/height/75/quality/100
-2843	Localvisão	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c704554bdcac437490143bc61b9aec87_19/version/0/width/120/height/75/quality/100
-2844	24Kitchen	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/481cf968448d4b07b8c675552a16ef8a_19/version/0/width/120/height/75/quality/100
-2845	STAR MOVIES	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3e7474629a5b416c8deaf0919002e6df_19/version/1/width/120/height/75/quality/100
-2846	National Geographic Wild	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b253e37f1334406f8e93c4b1c37470de_19/version/0/width/120/height/75/quality/100
-2847	STAR CRIME	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25769e8d419c4ea6b63d8097352b9cae_19/version/1/width/120/height/75/quality/100
-2849	Sky News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4d862190e6c549ad8f006f429ac53e52_19/version/0/width/120/height/75/quality/100
-2852	Benfica TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/477cd7f5a7354324b6a9a27db865708f_19/version/0/width/120/height/75/quality/100
-2854	TV Record	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/36bba6cd2b5746dc9a073e3e7817ec30_19/version/0/width/120/height/75/quality/100
-2859	RTL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ed68fc2259e34e329d66e4974331526a_19/version/0/width/120/height/75/quality/100
-2884	TCV News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cb1a4d4cc1b0472eb67ce43136c8f332_19/version/0/width/120/height/75/quality/100
-2890	NHK World	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf86b0c0b7714c90a27e881bbbb61ecc_19/version/0/width/120/height/75/quality/100
-2893	STAR COMEDY	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ea358343e7c4465c93ad1872e52ff0d6_19/version/1/width/120/height/75/quality/100
-2897	KBS WORLD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e23a084076eb46cabc7a2fce55e6c113_19/version/0/width/120/height/75/quality/100
-2902	Canal Q	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e1ebf412bd444a61afdd2d9fa1263e1a_19/version/0/width/120/height/75/quality/100
-2903	Fight Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4dcc70dcdde34d708b9ec9b1a861c8ad_19/version/0/width/120/height/75/quality/100
-2914	Discovery	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fa191c5ad6ba48b9bca783dafabc7498_19/version/0/width/120/height/75/quality/100
-2915	SIC Radical	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5a461799731d4344b277dcae381f0a89_19/version/0/width/120/height/75/quality/100
-2925	MTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9108b7d984a54a43b441bb44b9a84b85_19/version/0/width/120/height/75/quality/100
-2927	Kuriakos TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57feab802d804da792867ebeacd0db17_19/version/0/width/120/height/75/quality/100
-2930	Sport TV +	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ce24543d73ab43b1b53dea9dc25d6854/version/0/width/120/height/75/quality/100
-2931	Mezzo Live	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/24f9fa496e70422a9830c2549dd1de0f_19/version/0/width/120/height/75/quality/100
-2933	Insight	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08526de0382f4a2095f6063d7a7490cd_19/version/0/width/120/height/75/quality/100
-2934	Docubox	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/efb948f799c2406187f8e3dcf9e29b1d_19/version/0/width/120/height/75/quality/100
-2935	SIC Notícias	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf33e03117ac4ece8cc3b260d4869c4a/version/0/width/120/height/75/quality/100
-2936	SIC Mulher	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c23aa79c4be64a78be3ea5843c079529_19/version/0/width/120/height/75/quality/100
-2937	SIC Caras	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/71c7fa677b894fecada52f4fdb1defb5_19/version/0/width/120/height/75/quality/100
-2938	SIC K	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e45f250d72334fbdb3dbe1d91c4bc751_19/version/0/width/120/height/75/quality/100
-2993	Travel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9487453658fd42d9a8e515ee072328e7_19/version/0/width/120/height/75/quality/100
-2994	Food Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57a9e479ba34434a8ef249b0cd560c94_19/version/0/width/120/height/75/quality/100
-2996	AMC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1b0fa6a1c5544a24bdea82e2bc9222e3_19/version/0/width/120/height/75/quality/100
-3004	Sporting TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/868cdc88b86b4033a6be7fd2652bd05e_19/version/0/width/120/height/75/quality/100
-3012	Disney Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2887957962b24db6beee92d0b470a54c_19/version/0/width/120/height/75/quality/100
-3015	Trace	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bc50304a4b45406595c55d24d0c3ff01_19/version/0/width/120/height/75/quality/100
-3016	Odisseia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/121e6e261b8749749c53c4248026ee49_19/version/0/width/120/height/75/quality/100
-3017	AMC Break	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/af39b08b3262477cbfd49e8a506855d4_19/version/1/width/120/height/75/quality/100
-3019	ARIRANG TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/083bfe803259450b9e59de9d799ae2b6_19/version/0/width/120/height/75/quality/100
-3020	TV Globo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f3715346f3e748c088eeacef18bef34b_19/version/0/width/120/height/75/quality/100
-3024	TVCine Edition	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6ba9073760e2487488ada139d1b1f7b7_19/version/0/width/120/height/75/quality/100
-3026	Hollywood	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d3a18b81bedc48c6aaf41b64c3d570fd_19/version/0/width/120/height/75/quality/100
-3027	Cinemundo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/653fc31c29e34d62a434156b905c7cff_19/version/0/width/120/height/75/quality/100
-3028	RTP1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a1bef425c634497b9341957d36e692c3_19/version/0/width/120/height/75/quality/100
-3414	CMTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9059345359844b3ca594134c8d81ffc0_19/version/0/width/120/height/75/quality/100
-3885	DAZN 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e9ce8b8d6d2e48df8e096cd271cc982d/version/1/width/120/height/75/quality/100
-3886	DAZN 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08734341d4c9452dbe272112d5a3aaee/version/1/width/120/height/75/quality/100
-3887	DAZN 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7c03993042f64f2e80b224a52c87f6e7/version/1/width/120/height/75/quality/100
-3888	DAZN 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9f8ed7e32fb04f819475d9eb5a38d2d5/version/1/width/120/height/75/quality/100
-3889	DAZN 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/53aa4f7847834e1f8678067be941c238/version/1/width/120/height/75/quality/100
-3890	DAZN  6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2e6186034d444f83b0bf2a87836d123b/version/1/width/120/height/75/quality/100
-4862	SportTV NBA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e0b906090d974186914f5cc909c5dce6/version/0/width/120/height/75/quality/100
-5043	EuroSport 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/13130dde270143ea90c7ad709cd33cda_19/version/0/width/120/height/75/quality/100
-5583	A Bola TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/81847fc044e84e7f8f3fc9b7a1cb7d01_19/version/1/width/120/height/75/quality/100
-5585	Canal 11	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3c6048c60dc042fd84e395b33d1f049e_19/version/0/width/120/height/75/quality/100
-5609	S+	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c63940e416dd47b28de10aa3477408b0_19/version/0/width/120/height/75/quality/100
-5610	FREEDOM	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/309a6fca4d47427ca9f5c8145a0348c1/version/0/width/120/height/75/quality/100
-5678	CNN Portugal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/15dc865f76db4f7baddb09d728bd1088/version/0/width/120/height/75/quality/100
-7075	GameToon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/28aac14ad6f7411092bc81bc383cc85b_19/version/0/width/120/height/75/quality/100
-7084	RTP Açores	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7e72b63606b74facb84d4a4be512ef6b_19/version/0/width/120/height/75/quality/100
-7090	Casa e Cozinha	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e465476b8a8545488e8310c1df29e55d_19/version/0/width/120/height/75/quality/100
-7185	Panda	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/85009bcb0b8b45e7bc140a4832ca014b_19/version/0/width/120/height/75/quality/100
-7187	RTP3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d430a0822b5f469ca320bf6d6723f0ca_19/version/0/width/120/height/75/quality/100
-7188	Panda Kids	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9352c739e9b34d7b9aad308b90f521e7_19/version/0/width/120/height/75/quality/100
-7250	Sport TV 6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f31ce4c726dd4382915bfdea05a3c50f/version/0/width/120/height/75/quality/100
-7522	Disney Junior	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bbbf77ecab4440d0876889aa0d62b586/version/0/width/120/height/75/quality/100
-8005	Cartoonito	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/14dd98d3e0574155bf9e8dee613d3161_19/version/2/width/120/height/75/quality/100
-8006	Cartoon Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/23dffe336ee24fba9879f8b43eb49571_19/version/0/width/120/height/75/quality/100
-8013	GINX Esports TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25a531732c4d4ff99bab6793ad20be65_19/version/0/width/120/height/75/quality/100
-8124	iConcerts	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/655bd3fbd7764b85b6c216cf352fa320_19/version/0/width/120/height/75/quality/100
-8368	UNIFE TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2b0d86675bb8428e91c55eada3982d01_19/version/0/width/120/height/75/quality/100
-8396	CNN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/48a5c03f05264f969c71e56992a98847_19/version/1/width/120/height/75/quality/100
-8397	TVI Reality	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/8ae0590068384f8b85de367df743188e_19/version/1/width/120/height/75/quality/100
-8398	TLC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd02f77c26cb4380a1da6a2fe90a938d_19/version/1/width/120/height/75/quality/100
-8399	V+ TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e2cbe6f3c7de4a77a37e4eb878b789f7_19/version/2/width/120/height/75/quality/100
-8424	RTP Madeira	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d6249f5eef264202874dfdd5de492a9e_19/version/1/width/120/height/75/quality/100
-8426	AMC Crime	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d01e00520a5a4a2aaa1e1bf32f199dd5_19/version/1/width/120/height/75/quality/100
-8529	Dizi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/87e626cfaddd45bba7703e3df96d2c38_19/version/0/width/120/height/75/quality/100
-8598	BenficaTV Multicam 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7ba831b33ef34380b3b5b462bbf355cf/version/0/width/120/height/75/quality/100
-8599	BenficaTV Multicam 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6d713fb010f543a7a1e9848d6c791620/version/0/width/120/height/75/quality/100
-8600	BenficaTV Multicam 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/370959aa138a4805886fccabf38265e0/version/0/width/120/height/75/quality/100
-8601	BenficaTV Multicam 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b02508077c564f7883f8fc860f15b9c9/version/0/width/120/height/75/quality/100
-8606	AfroMusic 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b22774537d39440495b205b428e83a7f/version/0/width/120/height/75/quality/100
-8636	Panda Biggs	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/383f7e6f14ba48a0a69bde850dae7f50/version/0/width/120/height/75/quality/100
-8645	Nickelodeon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a5f17d29c7d4e74bea71046ffc50569/version/0/width/120/height/75/quality/100
-8646	MCM POP	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/610a1c775a4d4f89954924575c738b0e/version/0/width/120/height/75/quality/100
-8711	News Now 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7d1df4bc7fd948e3bbb57fefe3845ffb/version/0/width/120/height/75/quality/100
-8735	SIC Novelas	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd9e43272bc04420969e8e8ff0de8f8c/version/0/width/120/height/75/quality/100
-8743	Sport TV 7	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/079ac81d79f7490e844af481e5303d12/version/2/width/120/height/75/quality/100
-8775	HGTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/89768f1e6c1043279925acef9cadf5b8/version/0/width/120/height/75/quality/100
-8776	Disc ID	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5aa45346d01440dabf96211bf118c28f/version/0/width/120/height/75/quality/100
-8781	BabyTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b422dbbb9fec4df5a07b6a383d906d56/version/0/width/120/height/75/quality/100
-8782	TCV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4280bb15af7b45068bbd15138531050b/version/0/width/120/height/75/quality/100
-8783	História	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f16aac14d6d54c8bb723397b3d743f08/version/0/width/120/height/75/quality/100

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -360,7 +360,7 @@ sub get_epg
                     # We can get the same programme for two different days if it goes past midnight.
                     # Lets remove duplicates here.
                     $xmlprogs{$channelId}{ $dtstart, $dtend } = \%prog;
-
+                    print( STDERR "  Adding programme: " . $prog{title}[0][0] . " [" . $dtstart . " - " . $dtend . "]\n" )  if( $opt->{debug} );
                 }
                 
             }

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -335,13 +335,53 @@ sub get_epg
                     }
                     
                     # fetch programme images in 16:9
-                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/height/480/quality/95" } ]  if ($programme->{images}[0]{url});
+                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/width/360/height/640/quality/95" } ]  if ($programme->{images}[0]{url} && $programme->{images}[0]{imageTypeName} eq "ca" );
+                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/width/640/height/360/quality/95" } ]  if ($programme->{images}[0]{url} && $programme->{images}[0]{imageTypeName} eq "cc");
 
                     if ( $programme->{tags}{genre} ) {
                         my @category = map { [ sanitizeUTF8($_->{value}) , 'pt' ] } @{$programme->{tags}{genre}{objects}};
                         $prog{category} = \@category;
                     }
                     $prog{country} = [ [ sanitizeUTF8($programme->{tags}{'country of production'}{objects}[0]{value}), 'pt' ] ] if $programme->{tags}{'country of production'};
+
+                    if ($programme->{tags}{'parental Rating'}) {
+                        my $rating;
+                        if ($programme->{tags}{'parental Rating'}{objects}[0]{value} == 0) {
+                            $rating = [ [ "All Ages", 'Portuguese Movie Rating' ] ];
+                        } else {
+                            $rating = [ [ "M/".$programme->{tags}{'parental Rating'}{objects}[0]{value}, 'Portuguese Movie Rating' ] ];
+                        }
+                        $prog{rating} = $rating if $rating; 
+                    }
+
+                    my @images;
+                    for my $image (@{$programme->{images}}) {
+                        next if !$image->{url};
+
+                        my $type = "";
+                        my $orient = "";
+                        my $size = 3;
+                        my $system = "vodafone";
+                        my $width = 640;
+                        my $height = 360;
+
+                        if ($image->{imageTypeName} eq "cc") {
+                            $orient = "L";
+                            $type = "still";
+                        } elsif ($image->{imageTypeName} eq "ca") {
+                            $orient = "P";
+                            $type = "poster";
+                            $width = 360;
+                            $height = 640;
+                        } elsif ($image->{imageTypeName} eq "bg") {
+                            $orient = "L";
+                            $type = "backdrop";
+                        }
+
+                        my $url = $image->{url};
+                        push @images, [ $image->{url}."/width/".$width."/height/".$height."/quality/95", { type => $type, size => $size, orient => $orient, system => $system } ];
+                    }
+                    $prog{image} = \@images if scalar @images;
 
                     $prog{date} = sanitizeUTF8($programme->{metas}{year}{value}) if $programme->{metas}{year}{value};
 

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -106,7 +106,6 @@ use utf8;
 use XMLTV;
 use XMLTV::Version "$XMLTV::VERSION";
 use DateTime;
-use DateTime::Format::Strptime;
 use Encode; # used to convert 'perl strings' into 'utf-8 strings'
 use XML::LibXML;
 use XMLTV::Configure::Writer;
@@ -278,10 +277,6 @@ sub get_epg
 
     my $channelInfo = _read_channel_data();
 
-    # start the day before to fetch potential programmes that started the previous day
-    $curDate->add(days => -1);
-    my @daily_blocks = ("18-00");
-
     while ( $curDate <=  $endDate ) {
 
         for my $channel (@channelList) {
@@ -300,11 +295,11 @@ sub get_epg
 
             $xmlchannels{ $channelId } = \%ch ;
 
-            my $date_day = $curDate->day;
-            my $date_month = $curDate->month;
+            my $date_day = $curDate->strftime('%d');
+            my $date_month = $curDate->strftime('%m');
             my $date_year = $curDate->year;
 
-            for my $period (@daily_blocks) {
+            for my $period ("00-06","06-12","12-18","18-00") {
 
                 print( STDERR "requesting EPG from " . $curDate->ymd() ." [".$period."]". " for " . $channelId . "\n" )  if( !$opt->{quiet} );
                 print( STDERR " GET ".$json_baseurl.$channel."/".$date_year."/".$date_month."/".$date_day."/".$period."\n" )  if( $opt->{debug} );
@@ -325,7 +320,6 @@ sub get_epg
                 for my $programme ( @{ $data }) {
                     my %prog;
                     my ($dtstart, $dtend, $starts_today) = make_dates($programme->{startDate}, $programme->{endDate}, $curDate);
-                    next PROGRAMME unless $starts_today;
 
                     $prog{start} = $dtstart;
                     $prog{stop} = $dtend;
@@ -374,7 +368,6 @@ sub get_epg
         }
 
         $curDate->add(days => 1);
-        @daily_blocks = ("00-06","06-12","12-18","18-00");
     }
 
     $writer->write_channel($_) for values %xmlchannels;

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -246,8 +246,11 @@ sub _read_channel_data
     open( my $input_fh, "<", $input_file ) || die "Can't open $input_file: $!";
     while (my $channel_string = <$input_fh>) {
         chomp($channel_string);
+        # remove commented channels
+        $channel_string =~ s/^#.*//;
         next if not length $channel_string;
         my @items = split("\t",$channel_string);
+        $items[1] =~ s/\"//g;
         $channel_list->{ $items[0] } = { 
             name => decode('UTF-8', $items[1]),
             icon => $items[2]
@@ -268,13 +271,14 @@ sub get_epg
     my %xmlprogs;
 
     my $curDate = $startDate;
-    my $nr_days = $startDate->delta_days($endDate)->days;
 
     my $channelInfo = _read_channel_data();
 
-    for my $day ( 0 .. $nr_days ) {
+    # start the day before to fetch potential programmes that started the previous day
+    $curDate->add(days => -1);
+    my @daily_blocks = ("18-00");
 
-        $curDate->add(days => $day);
+    while ( $curDate <=  $endDate ) {
 
         for my $channel (@channelList) {
 
@@ -285,7 +289,8 @@ sub get_epg
             );
             # multiple display-names are ok and may be useful to match other tools lists
             my @displayname = ( [  sanitizeUTF8( $channelInfo->{$channel}->{name} ), 'pt' ] ,
-                                [  sanitizeUTF8( $channelId ), 'pt' ] );
+                                [  sanitizeUTF8( $channelId ), 'pt' ] ,
+                                [  sanitizeUTF8( $channel ), 'pt' ] );
 
             push @{ $ch{'display-name'} }, @displayname ;
 
@@ -295,9 +300,9 @@ sub get_epg
             my $date_month = $curDate->month;
             my $date_year = $curDate->year;
 
-            for my $period ("00-06","06-12","12-18","18-00") {
+            for my $period (@daily_blocks) {
 
-                print( STDERR "requesting EPG from " . $curDate->ymd() ." [".$period."]". " for " . $channel . "\n" )  if( !$opt->{quiet} );
+                print( STDERR "requesting EPG from " . $curDate->ymd() ." [".$period."]". " for " . $channelId . "\n" )  if( !$opt->{quiet} );
                 print( STDERR " GET ".$json_baseurl.$channel."/".$date_year."/".$date_month."/".$date_day."/".$period."\n" )  if( $opt->{debug} );
 
                 my $epgSource = json_request('get', $channel."/".$date_year."/".$date_month."/".$date_day."/".$period);
@@ -331,7 +336,8 @@ sub get_epg
                         $prog{length} = $duration_items[2]*3600+$duration_items[3]*60+$duration_items[4] if scalar @duration_items;
                     }
                     
-                    $prog{icon} = [ { src => $programme->{images}[0]{url} } ]  if ($programme->{images}[0]{url});
+                    # fetch programme images in 16:9
+                    $prog{icon} = [ { src => $programme->{images}[0]{url}."/width/854/height/480/quality/95" } ]  if ($programme->{images}[0]{url});
 
                     if ( $programme->{tags}{genre} ) {
                         my @category = map { [ sanitizeUTF8($_->{value}) , 'pt' ] } @{$programme->{tags}{genre}{objects}};
@@ -361,11 +367,10 @@ sub get_epg
                 
             }
 
-
         }
 
-
-        $curDate->add( days => 1);
+        $curDate->add(days => 1);
+        @daily_blocks = ("00-06","06-12","12-18","18-00");
     }
 
     $writer->write_channel($_) for values %xmlchannels;
@@ -388,7 +393,7 @@ sub json_request {
     my ($method, $path, $content) = @_;
 
     # TODO(nsenica): Implement proper throttling control.
-    sleep(1);
+    sleep(0.1);
     
     my $url = $json_baseurl . $path;
 
@@ -473,12 +478,11 @@ sub make_dates
 sub make_channelid
 {
     my( $id ) = @_;
-    $id = decode 'UTF-8', $id;
     $id = lc( $id );      # turn into lowercase
     $id =~ s/\s+//g;      # remove whitespace
     $id =~ s/&//g;        # remove ampersand
     $id =~ s/!//g;        # remove !
-    $id =~ s/\x{e7}/c/g;  # turn c-cecille into plain c
+    $id =~ s/\"//g;       # remove ""
     $id =~ s/\+/-plus/g;  # turn + into -plus
     $id = unidecode($id);
     $id .= '.tv.vodafone.pt'; # append domain part

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -115,15 +115,14 @@ use XMLTV::Options qw/ParseOptions/;
 use JSON;
 use URI::Escape qw/ uri_escape /;
 use URI::Encode qw/ uri_encode uri_decode/;
-#use Data::Dump qw/pp/; # uncomment to debug
+use Data::Dump qw/pp/; # uncomment to debug
 
 my $maxdays = 1+6; # data source is limited to 7 days (including today)
 
 my $grabber_name = 'tv_grab_pt_vodafone';
-my $grabber_version = '2.00';
+my $grabber_version = '3.00';
 
-my $json_baseurl = 'https://web.ott-red.vodafone.pt';
-my $json_api = '/ott3_webapp/';
+my $json_baseurl = 'https://cdn.pt.vtv.vodafone.com/epg/';
 
 my $ua = LWP::UserAgent->new(ssl_opts => {
     SSL_cipher_list => 'DEFAULT:!DH',
@@ -174,7 +173,7 @@ $writer->start({
     'generator-info-name' => "XMLTV/".$opt->{version},
     'generator-info-url' => 'http://www.xmltv.org/',
     'source-info-name' => 'EPG Service for Vodafone',
-    'source-info-url' => $json_baseurl.$json_api."guia-tv",
+    'source-info-url' => $json_baseurl,
 });
 
 if ($opt->{days} > 0) {
@@ -193,128 +192,175 @@ if ($opt->{days} > 0) {
 $writer->end();
 
 if( $is_success ) {
-     exit 0;
+    exit 0;
 } else {
-     exit 1;
+    exit 1;
 }
 
 sub config_stage
 {
-     my( $stage, $conf ) = @_;
-     die "Unknown stage $stage" if $stage ne "start";
+    my( $stage, $conf ) = @_;
+    die "Unknown stage $stage" if $stage ne "start";
 
-     my $result;
-     my $writer = new XMLTV::Configure::Writer( OUTPUT => \$result, encoding => 'utf-8' );
-     $writer->start( { grabber => 'tv_grab_pt_vodafone' } );
-     $writer->end( 'select-channels' );
+    my $result;
+    my $writer = new XMLTV::Configure::Writer( OUTPUT => \$result, encoding => 'utf-8' );
+    $writer->start( { grabber => 'tv_grab_pt_vodafone' } );
+    $writer->end( 'select-channels' );
 
-     return $result;
+    return $result;
 }
 
-sub list_channels
+sub list_channels 
 {
-     my( $conf, $opt ) = @_;
+    my ( $conf, $opt ) = @_;
 
-     # Return a string containing an xmltv-document with <channel>-elements
-     # for all available channels.
+    my $channellist = _read_channel_data();
 
-     my $channellist=json_request( 'get', 'v1/channels' );
+    my $output=XML::LibXML::Document->new( '1.0', 'utf-8' );
+    my $root=XML::LibXML::Element->new( 'tv' );
+    $output->setDocumentElement( $root );
 
-     $channellist = $channellist->{data};
+    foreach my $key ( keys %$channellist ) {
+        my $channel=$channellist->{$key};
+        my $sigla=$key;
+        my $name=$channel->{name};
+        my $icon=$channel->{icon};
+        my $tmp=XML::LibXML::Element->new( 'channel' );
+        $tmp->setAttribute( 'id', encode( 'UTF-8', $sigla ) );
+        $tmp->appendTextChild( 'display-name', encode( 'UTF-8', $name ) );
+        my $iconElement=XML::LibXML::Element->new( 'icon' );
+        $iconElement->setAttribute( 'src', $icon );
+        $tmp->appendChild( $iconElement );
+        $root->appendChild( $tmp );
+    }
 
-     my $output=XML::LibXML::Document->new( '1.0', 'utf-8' );
-     my $root=XML::LibXML::Element->new( 'tv' );
-     $output->setDocumentElement( $root );
+    return $output->toString();
 
-     foreach my $channel( @$channellist ) {
-         #pp( $channel ) if( $opt->{debug} ); # uncomment to debug
-
-         my $name=$channel->{name};
-         my $sigla=$channel->{id};
-         my $tmp=XML::LibXML::Element->new( 'channel' );
-         $tmp->setAttribute( 'id', encode( 'UTF-8', $sigla ) );
-         $tmp->appendTextChild( 'display-name', encode( 'UTF-8', $name ) );
-         $root->appendChild( $tmp );
-     }
-
-     return $output->toString();
 }
+
+sub _read_channel_data
+{
+    my $channel_list = {};
+    my $c = 0;
+    while (my $channel_string = <DATA>) {
+        chomp($channel_string);
+        next if not length $channel_string;
+        my @items = split("\t",$channel_string);
+        $channel_list->{ $items[0] } = { 
+            name => $items[1],
+            icon => $items[2]
+        } ;
+        last;
+    }
+
+    return $channel_list
+}
+
 
 sub get_epg
 {
     my( $writer, $startDate, $endDate ) = @_;
 
-    my $baseRequest = 'v1.5/programs/grids/';
     my @channelList = @{$conf->{channel}};
-
-    my $curDate = $startDate;
 
     my %xmlchannels;
     my %xmlprogs;
 
+    my $curDate = $startDate;
     my $nr_days = $startDate->delta_days($endDate)->days;
+
+    my $channelInfo = _read_channel_data();
 
     for my $day (0..$nr_days) {
 
-        my $epg_day = $day + $opt->{offset};
+        $curDate->add(days => $day);
 
         for my $channel (@channelList) {
 
-            my $encoded_channel = uri_encode($channel);
-
-            print( STDERR "requesting EPG from " . $curDate->ymd() . " for " . $encoded_channel . "\n" )  if( !$opt->{quiet} );
-            print( STDERR " GET ".$json_baseurl.$json_api.$baseRequest.$encoded_channel."/".$epg_day."\n" )  if( $opt->{debug} );
-
-            my $epgSource = json_request('get', $baseRequest."/".$encoded_channel."/".$epg_day);
-
-            if ( ! $epgSource ){
-                die("Bad EPG download, probably channel list is outdated, rerun the grabber configure to update the list.\n" ); }
-            elsif ( !$epgSource->{data} || scalar @{$epgSource->{data}} == 0 ){
-                print( STDERR " Empty EPG download for ".$channel.", probably channel list is outdated or no API data for that channel\n" .
-                "  Rerun the grabber configure to update the list or check for the channel EPG in the Vodafone app.\n" );
-                next;
-            };
-
-            my $data = $epgSource->{data};
-
-            my $channelId = make_channelid( $data->[0]->{channel}->{id} );
+            my $channelId = make_channelid( $channelInfo->{$channel}->{name} );
             my %ch = (
                 'id' => $channelId,
-                'icon' => [ { src =>  $data->[0]->{channel}->{logo} } ],
+                'icon' => [ { src =>  $channelInfo->{$channel}->{icon} } ],
             );
             # multiple display-names are ok and may be useful to match other tools lists
-            my @displayname = ( [  sanitizeUTF8( $data->[0]->{channel}->{name} ), 'pt' ] ,
-                                [  sanitizeUTF8( $data->[0]->{channel}->{id} ),   'pt' ] );
+            my @displayname = ( [  sanitizeUTF8( $channelInfo->{$channel}->{name} ), 'pt' ] ,
+                                [  sanitizeUTF8( $channelId ),   'pt' ] );
 
             push @{ $ch{'display-name'} }, @displayname ;
 
             $xmlchannels{ $channelId } = \%ch ;
 
-            PROGRAMME:
-            for my $programme ( @{ $data }) {
-                my %prog;
-                my ($dtstart, $dtend, $starts_today) = make_dates($programme->{startTime}, $programme->{endTime}, $curDate);
-                next PROGRAMME unless $starts_today;
+            my $date_day = $curDate->day;
+            my $date_month = $curDate->month;
+            my $date_year = $curDate->year;
 
-                $prog{start} = $dtstart;
-                $prog{stop} = $dtend;
+            for my $period ("00-06","06-12","12-18","18-00") {
 
-                $prog{channel} = $channelId;
-                $prog{title} = [ [ sanitizeUTF8($programme->{title}), 'pt' ] ];
-                $prog{desc} = [ [ sanitizeUTF8($programme->{description}), 'pt' ] ]                     if ($programme->{description});
-                $prog{length} = ( $programme->{duration} )                                              if ($programme->{duration});
-                $prog{icon} = [ { src => $programme->{image} } ]                                        if ($programme->{image});
+                print( STDERR "requesting EPG from " . $curDate->ymd() ." [".$period."]". " for " . $channel . "\n" )  if( !$opt->{quiet} );
+                print( STDERR " GET ".$json_baseurl.$channel."/".$date_year."/".$date_month."/".$date_day."/".$period."\n" )  if( $opt->{debug} );
 
-                $prog{category} = [ [ sanitizeUTF8($programme->{channel}{category}), 'pt' ] ]           if ($programme->{channel}{category});
-                $prog{'sub-title'}   = [ [ sanitizeUTF8($programme->{series}{episodeTitle}), 'pt' ] ]   if ($programme->{series}->{episodeTitle}) ;
+                my $epgSource = json_request('get', $channel."/".$date_year."/".$date_month."/".$date_day."/".$period);
 
-                $prog{'episode-num'} = make_episode_num($programme);
+                if ( ! $epgSource ){
+                    die("Bad EPG download, probably channel list is outdated, rerun the grabber configure to update the list.\n" ); }
+                elsif ( !$epgSource->{result} || !$epgSource->{result}->{objects} || scalar @{$epgSource->{result}->{objects}} == 0 ){
+                    print( STDERR " Empty EPG download for ".$channel.", probably channel list is outdated or no API data for that channel\n" .
+                    "  Rerun the grabber configure to update the list or check for the channel EPG in the Vodafone app.\n" );
+                    next;
+                };
 
-                # We can get the same programme for two different days if it goes past midnight.
-                # Lets remove duplicates here.
-                $xmlprogs{$channelId}{ $dtstart, $dtend } = \%prog;
+                my $data = $epgSource->{result}->{objects};
 
+                #pp $data;
+                #exit;
+
+                PROGRAMME:
+                for my $programme ( @{ $data }) {
+                    my %prog;
+                    my ($dtstart, $dtend, $starts_today) = make_dates($programme->{startDate}, $programme->{endDate}, $curDate);
+                    next PROGRAMME unless $starts_today;
+
+                    $prog{start} = $dtstart;
+                    $prog{stop} = $dtend;
+
+                    $prog{channel} = $channelId;
+                    $prog{title} = [ [ sanitizeUTF8($programme->{name}), 'pt' ] ];
+                    $prog{desc} = [ [ sanitizeUTF8($programme->{description}), 'pt' ] ]                     if ($programme->{description});
+
+                    if ($programme->{metas}{'display duration'}{value}) {
+                        my $duration_str = $programme->{metas}{'display duration'}{value};
+                        my @duration_items = split(/[PTHMS]/,$duration_str);
+                        $prog{length} = $duration_items[2]*3600+$duration_items[3]*60+$duration_items[4] if scalar @duration_items;
+                    }
+                    
+                    $prog{icon} = [ { src => $programme->{images}[0]{url} } ]                                        if ($programme->{images}[0]{url});
+
+                    if ( $programme->{tags}{genre} ) {
+                        my @category = map { [ sanitizeUTF8($_->{value}) , 'pt' ] } @{$programme->{tags}{genre}{objects}};
+                        $prog{category} = \@category;
+                    }
+                    $prog{country} = [ [ sanitizeUTF8($programme->{tags}{'country of production'}{objects}[0]{value}), 'pt' ] ] if $programme->{tags}{'country of production'};
+                    $prog{date} = sanitizeUTF8($programme->{metas}{year}{value}) if $programme->{tags}{year};
+                    if ( $programme->{tags}{actors} ) {
+                        my @actors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{actors}{objects}};
+                        $prog{credits}{actor} = \@actors;                        
+                    }
+                    if ( $programme->{tags}{director} ) {
+                        my @directors = map { sanitizeUTF8($_->{value}) } @{$programme->{tags}{director}{objects}} ;
+                        $prog{credits}{director} = \@directors;
+                    }
+
+                    $prog{'episode-num'} = make_episode_num($programme);
+
+                    # We can get the same programme for two different days if it goes past midnight.
+                    # Lets remove duplicates here.
+                    $xmlprogs{$channelId}{ $dtstart, $dtend } = \%prog;
+
+                }
+                
             }
+
+
         }
 
 
@@ -338,13 +384,10 @@ sub sanitizeUTF8 {
 sub json_request {
     my ($method, $path, $content) = @_;
 
-    my $url;
-    if($path =~ /^\//) {
-        $url = $json_baseurl . $path;
-    }
-    else {
-        $url = $json_baseurl . $json_api . $path;
-    }
+    # TODO(nsenica): Implement proper throttling control.
+    sleep(1);
+    
+    my $url = $json_baseurl . $path;
 
     print( STDERR "json_request(" . $method . ") url: " . $url . "\n" ) if( $opt->{debug} );
 
@@ -376,34 +419,31 @@ sub make_episode_num
 {
     my ($programme) = @_;
 
-    return unless $programme->{series};
+    return unless $programme->{metas}{'season number'};
 
     my $output;
 
     my $season;
     my $episode;
 
-    if ( $programme->{series}{season} ) {
-        $season = $programme->{series}{season} - 1;
+    if ( $programme->{metas}{'season number'}{value} ) {
+        $season = $programme->{metas}{'season number'}{value} - 1;
     }
 
-    if ( $programme->{series}{episode} ) {
-        $episode = $programme->{series}{episode} - 1;
+    if ( $programme->{metas}{'episode num'}{value} ) {
+        $episode = $programme->{metas}{'episode num'}{value} - 1;
     }
 
     $output = [ [ ($season // "") . "." . ($episode // "") . ".", 'xmltv_ns' ] ] if (defined $season || defined $episode);
 
-    my $seasonLabel = sanitizeUTF8($programme->{series}{seasonLabel})                            if ($programme->{series}{seasonLabel}) ;
-    my $episodeLabel = sanitizeUTF8($programme->{series}{episodeLabel})                          if ($programme->{series}{episodeLabel}) ;
-
-    if ( defined $seasonLabel && defined $episodeLabel ) {
-        push @{ $output }, [ $seasonLabel ." ". $episodeLabel , 'onscreen' ];
+    if ( defined $season && defined $episode ) {
+        push @{ $output }, [ ($season+1) ." ". ($episode+1) , 'onscreen' ];
     }
-    elsif ( defined $seasonLabel ) {
-        push @{ $output }, [ $seasonLabel , 'onscreen' ];
+    elsif ( defined $season ) {
+        push @{ $output }, [ ($season+1) , 'onscreen' ];
     }
-    elsif ( defined $episodeLabel ) {
-        push @{ $output }, [ $episodeLabel , 'onscreen' ];
+    elsif ( defined $episode ) {
+        push @{ $output }, [ ($episode+1) , 'onscreen' ];
     }
     return $output;
 
@@ -413,16 +453,14 @@ sub make_dates
 {
     my( $startTime, $endTime, $curDate ) = @_;
 
-    my $strp = new DateTime::Format::Strptime( pattern => '%FT%TZ' );
-
-    my $dtstart = $strp->parse_datetime($startTime);
+    my $dtstart = DateTime->from_epoch(epoch => $startTime);
     my $starts_today = 0;
     # does the programme start on the day we want listings for?
     if ($dtstart->day == $curDate->day) {
         $starts_today = 1;
     }
 
-    my $dtend = $strp->parse_datetime($endTime);
+    my $dtend = DateTime->from_epoch(epoch =>$endTime);
 
     # dates look like GMT, we tried UTC but in summer time they fail
     #return ($dtstart->strftime( '%Y%m%d%H%M%S %z' ), $dtend->strftime( '%Y%m%d%H%M%S %z' ));
@@ -442,3 +480,150 @@ sub make_channelid
     $id .= '.tv.vodafone.pt'; # append domain part
     return( $id );
 }
+
+
+# Generate with:
+# jq -r '.channels[]|(.epgId,.title,.logo.color.uri)' channel.list.new | sed 'N;N; s/\n/\t/g' | sort > channel.list
+__DATA__
+2670	SIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/807cd0cdbf314c44a0a5d9c852b2f835_19/version/0/width/120/height/75/quality/100
+2671	TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a70ebda1d51b436d909cebf8b424b10e/version/0/width/120/height/75/quality/100
+2673	História SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ffe30fdefa448ec8571115ff786ef14_19/version/0/width/120/height/75/quality/100
+2674	SyFy SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/656c66e4f9784c5aacfe8a056df4e4b3_19/version/0/width/120/height/75/quality/100
+2675	Eurosport	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9e5ca9dad53a4dc88a3e0eb367015327_19/version/0/width/120/height/75/quality/100
+2687	Sport TV 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a524ac5886ff494086e707103e124cc7/version/0/width/120/height/75/quality/100
+2688	Sport TV 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2f08d170f2a34e6390eb533a3d86538e/version/0/width/120/height/75/quality/100
+2689	Sport TV 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bae1291a65b240abbc98c8d92f7d9718/version/0/width/120/height/75/quality/100
+2690	Sport TV 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/316b4ac356244f4f96c4c64b05946be3/version/0/width/120/height/75/quality/100
+2691	Sport TV 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/27da1d086e1e4a8a9e3003d3ef5e5f4e/version/0/width/120/height/75/quality/100
+2692	Fuel TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/721d0d21b99c4b239ccb9b2daf54596c_19/version/0/width/120/height/75/quality/100
+2700	AXN Movies	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/37500ae831f84b30822e5bd5e04fd882_19/version/0/width/120/height/75/quality/100
+2701	SyFy	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a0409944e5542a9b5acb0647467203a_19/version/0/width/120/height/75/quality/100
+2706	Fashion TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/0b7ab6b146da42d582433ebde0ee70ee_19/version/0/width/120/height/75/quality/100
+2709	Canção Nova	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5604f4864c104703bb3b46ec71f91114_19/version/0/width/120/height/75/quality/100
+2710	TV Galícia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3af7d6ee83df46d7ab1d30a3c072e61d_19/version/0/width/120/height/75/quality/100
+2712	TVCine Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2723399dc06b4b9e8914b29467e23dab_19/version/0/width/120/height/75/quality/100
+2713	AXN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a44800b441224087aea741f0bf74263c_19/version/0/width/120/height/75/quality/100
+2715	STAR CHANNEL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/777adf78621046109570913715ab336c_19/version/1/width/120/height/75/quality/100
+2717	STAR LIFE	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5022d2f187a646d696cb57f977a0c9d1_19/version/1/width/120/height/75/quality/100
+2723	Trace Toca	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3178257df111483684efa8efb63e5309_19/version/0/width/120/height/75/quality/100
+2727	RTP Memória	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/79a94c670a9943d895f2eaca4e72780b_19/version/0/width/120/height/75/quality/100
+2728	RTP África	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b61b8cc6bbaf4aa6961861c2e072290e_19/version/0/width/120/height/75/quality/100
+2736	AR TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3cef63b6677f451d8164a908b6a1aa00_19/version/0/width/120/height/75/quality/100
+2741	National Geographic	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dfe23167f5144543bab68ea436dd1d15_19/version/0/width/120/height/75/quality/100
+2742	TV5Monde	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fd9db0bfa1e74eaeb29f0034eec69fa2_19/version/0/width/120/height/75/quality/100
+2743	CMUSIC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b94207010d994916a318e040c2d22f72_19/version/0/width/120/height/75/quality/100
+2744	Baby TV SD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6e324dd3e2db4ca6998cf6a1bb73870d_19/version/0/width/120/height/75/quality/100
+2747	Euronews	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3346c27cb8044e5dbc17548d9610e2e8_19/version/0/width/120/height/75/quality/100
+2748	TVEi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/dd60890cbbbf4704a89968766f0a1c3a_19/version/0/width/120/height/75/quality/100
+2749	TVE 24	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a861422493ed454994f7b7a69183846b_19/version/0/width/120/height/75/quality/100
+2750	CNBC Europe	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/969b0d2e8fe74a0db71c223f404f0ac6_19/version/0/width/120/height/75/quality/100
+2751	TPA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4e002a07acb84b02a86a19dba5ee102e_19/version/0/width/120/height/75/quality/100
+2754	MTV 00s 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c7f1040e19d940da8eec26928c0319de/version/0/width/120/height/75/quality/100
+2757	ProTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25f5f1ac6ede4d65ab0ebf0f05908088_19/version/0/width/120/height/75/quality/100
+2760	Bloomberg	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/aa36677a7a9941af9e07444dd21b525d_19/version/0/width/120/height/75/quality/100
+2765	Nautical Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3ecdccfb21a5429e8d44bf2f29e4dd34_19/version/0/width/120/height/75/quality/100
+2766	Phoenix	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1957a8e6b0c44b66ab2e0ad91fbec763_19/version/0/width/120/height/75/quality/100
+2768	Porto Canal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/16cdb28b90cb46b1aee589be8a477eff_19/version/0/width/120/height/75/quality/100
+2769	France 24 English	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d575daeef80442598a33b1cffa5a21a5_19/version/0/width/120/height/75/quality/100
+2770	France 24 FR	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e5013d5b45304e77a8911ae9d76c59ea_19/version/0/width/120/height/75/quality/100
+2772	RAI 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/30137cc9eb7f472bb80cfbea196f524d_19/version/0/width/120/height/75/quality/100
+2779	MCM Top	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/18855da1bce845b7b7611689f2303f8b_19/version/0/width/120/height/75/quality/100
+2781	DW	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/be6a088466484a99a99842ec524895f6_19/version/0/width/120/height/75/quality/100
+2784	AlJazeera	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/803a229c5eb146ba90f22a763c49c0c7_19/version/0/width/120/height/75/quality/100
+2812	Record News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f7b7a4b51ead4f5d8028669c0287ff7c_19/version/0/width/120/height/75/quality/100
+2825	RTP2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f47f5f7d4acd493891cb1225d10024e2_19/version/0/width/120/height/75/quality/100
+2831	TVCine Emotion	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c3a60cce67a347ecad3ae6fae99e1646_19/version/0/width/120/height/75/quality/100
+2832	TVCine Action	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c47a0066a7244f51beeeba84fbf46424_19/version/0/width/120/height/75/quality/100
+2833	AXN White	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f54c7528c31947c8be68f13748cd15b0_19/version/0/width/120/height/75/quality/100
+2837	E!	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/502684fe51d24e6cb81551b3b2d54ca9_19/version/0/width/120/height/75/quality/100
+2843	Localvisão	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c704554bdcac437490143bc61b9aec87_19/version/0/width/120/height/75/quality/100
+2844	24Kitchen	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/481cf968448d4b07b8c675552a16ef8a_19/version/0/width/120/height/75/quality/100
+2845	STAR MOVIES	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3e7474629a5b416c8deaf0919002e6df_19/version/1/width/120/height/75/quality/100
+2846	National Geographic Wild	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b253e37f1334406f8e93c4b1c37470de_19/version/0/width/120/height/75/quality/100
+2847	STAR CRIME	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25769e8d419c4ea6b63d8097352b9cae_19/version/1/width/120/height/75/quality/100
+2849	Sky News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4d862190e6c549ad8f006f429ac53e52_19/version/0/width/120/height/75/quality/100
+2852	Benfica TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/477cd7f5a7354324b6a9a27db865708f_19/version/0/width/120/height/75/quality/100
+2854	TV Record	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/36bba6cd2b5746dc9a073e3e7817ec30_19/version/0/width/120/height/75/quality/100
+2859	RTL	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ed68fc2259e34e329d66e4974331526a_19/version/0/width/120/height/75/quality/100
+2884	TCV News	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cb1a4d4cc1b0472eb67ce43136c8f332_19/version/0/width/120/height/75/quality/100
+2890	NHK World	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf86b0c0b7714c90a27e881bbbb61ecc_19/version/0/width/120/height/75/quality/100
+2893	STAR COMEDY	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ea358343e7c4465c93ad1872e52ff0d6_19/version/1/width/120/height/75/quality/100
+2897	KBS WORLD	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e23a084076eb46cabc7a2fce55e6c113_19/version/0/width/120/height/75/quality/100
+2902	Canal Q	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e1ebf412bd444a61afdd2d9fa1263e1a_19/version/0/width/120/height/75/quality/100
+2903	Fight Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4dcc70dcdde34d708b9ec9b1a861c8ad_19/version/0/width/120/height/75/quality/100
+2914	Discovery	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/fa191c5ad6ba48b9bca783dafabc7498_19/version/0/width/120/height/75/quality/100
+2915	SIC Radical	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5a461799731d4344b277dcae381f0a89_19/version/0/width/120/height/75/quality/100
+2925	MTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9108b7d984a54a43b441bb44b9a84b85_19/version/0/width/120/height/75/quality/100
+2927	Kuriakos TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57feab802d804da792867ebeacd0db17_19/version/0/width/120/height/75/quality/100
+2930	Sport TV +	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/ce24543d73ab43b1b53dea9dc25d6854/version/0/width/120/height/75/quality/100
+2931	Mezzo Live	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/24f9fa496e70422a9830c2549dd1de0f_19/version/0/width/120/height/75/quality/100
+2933	Insight	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08526de0382f4a2095f6063d7a7490cd_19/version/0/width/120/height/75/quality/100
+2934	Docubox	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/efb948f799c2406187f8e3dcf9e29b1d_19/version/0/width/120/height/75/quality/100
+2935	SIC Notícias	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/cf33e03117ac4ece8cc3b260d4869c4a/version/0/width/120/height/75/quality/100
+2936	SIC Mulher	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c23aa79c4be64a78be3ea5843c079529_19/version/0/width/120/height/75/quality/100
+2937	SIC Caras	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/71c7fa677b894fecada52f4fdb1defb5_19/version/0/width/120/height/75/quality/100
+2938	SIC K	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e45f250d72334fbdb3dbe1d91c4bc751_19/version/0/width/120/height/75/quality/100
+2993	Travel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9487453658fd42d9a8e515ee072328e7_19/version/0/width/120/height/75/quality/100
+2994	Food Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/57a9e479ba34434a8ef249b0cd560c94_19/version/0/width/120/height/75/quality/100
+2996	AMC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/1b0fa6a1c5544a24bdea82e2bc9222e3_19/version/0/width/120/height/75/quality/100
+3004	Sporting TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/868cdc88b86b4033a6be7fd2652bd05e_19/version/0/width/120/height/75/quality/100
+3012	Disney Channel	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2887957962b24db6beee92d0b470a54c_19/version/0/width/120/height/75/quality/100
+3015	Trace	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bc50304a4b45406595c55d24d0c3ff01_19/version/0/width/120/height/75/quality/100
+3016	Odisseia	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/121e6e261b8749749c53c4248026ee49_19/version/0/width/120/height/75/quality/100
+3017	AMC Break	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/af39b08b3262477cbfd49e8a506855d4_19/version/1/width/120/height/75/quality/100
+3019	ARIRANG TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/083bfe803259450b9e59de9d799ae2b6_19/version/0/width/120/height/75/quality/100
+3020	TV Globo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f3715346f3e748c088eeacef18bef34b_19/version/0/width/120/height/75/quality/100
+3024	TVCine Edition	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6ba9073760e2487488ada139d1b1f7b7_19/version/0/width/120/height/75/quality/100
+3026	Hollywood	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d3a18b81bedc48c6aaf41b64c3d570fd_19/version/0/width/120/height/75/quality/100
+3027	Cinemundo	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/653fc31c29e34d62a434156b905c7cff_19/version/0/width/120/height/75/quality/100
+3028	RTP1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/a1bef425c634497b9341957d36e692c3_19/version/0/width/120/height/75/quality/100
+3414	CMTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9059345359844b3ca594134c8d81ffc0_19/version/0/width/120/height/75/quality/100
+3885	DAZN 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e9ce8b8d6d2e48df8e096cd271cc982d/version/1/width/120/height/75/quality/100
+3886	DAZN 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/08734341d4c9452dbe272112d5a3aaee/version/1/width/120/height/75/quality/100
+3887	DAZN 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7c03993042f64f2e80b224a52c87f6e7/version/1/width/120/height/75/quality/100
+3888	DAZN 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9f8ed7e32fb04f819475d9eb5a38d2d5/version/1/width/120/height/75/quality/100
+3889	DAZN 5	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/53aa4f7847834e1f8678067be941c238/version/1/width/120/height/75/quality/100
+3890	DAZN  6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2e6186034d444f83b0bf2a87836d123b/version/1/width/120/height/75/quality/100
+4862	SportTV NBA	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e0b906090d974186914f5cc909c5dce6/version/0/width/120/height/75/quality/100
+5043	EuroSport 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/13130dde270143ea90c7ad709cd33cda_19/version/0/width/120/height/75/quality/100
+5583	A Bola TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/81847fc044e84e7f8f3fc9b7a1cb7d01_19/version/1/width/120/height/75/quality/100
+5585	Canal 11	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/3c6048c60dc042fd84e395b33d1f049e_19/version/0/width/120/height/75/quality/100
+5609	S+	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/c63940e416dd47b28de10aa3477408b0_19/version/0/width/120/height/75/quality/100
+5610	FREEDOM	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/309a6fca4d47427ca9f5c8145a0348c1/version/0/width/120/height/75/quality/100
+5678	CNN Portugal	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/15dc865f76db4f7baddb09d728bd1088/version/0/width/120/height/75/quality/100
+7075	GameToon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/28aac14ad6f7411092bc81bc383cc85b_19/version/0/width/120/height/75/quality/100
+7084	RTP Açores	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7e72b63606b74facb84d4a4be512ef6b_19/version/0/width/120/height/75/quality/100
+7090	Casa e Cozinha	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e465476b8a8545488e8310c1df29e55d_19/version/0/width/120/height/75/quality/100
+7185	Panda	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/85009bcb0b8b45e7bc140a4832ca014b_19/version/0/width/120/height/75/quality/100
+7187	RTP3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d430a0822b5f469ca320bf6d6723f0ca_19/version/0/width/120/height/75/quality/100
+7188	Panda Kids	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/9352c739e9b34d7b9aad308b90f521e7_19/version/0/width/120/height/75/quality/100
+7250	Sport TV 6	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f31ce4c726dd4382915bfdea05a3c50f/version/0/width/120/height/75/quality/100
+7522	Disney Junior	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bbbf77ecab4440d0876889aa0d62b586/version/0/width/120/height/75/quality/100
+8005	Cartoonito	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/14dd98d3e0574155bf9e8dee613d3161_19/version/2/width/120/height/75/quality/100
+8006	Cartoon Network	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/23dffe336ee24fba9879f8b43eb49571_19/version/0/width/120/height/75/quality/100
+8013	GINX Esports TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/25a531732c4d4ff99bab6793ad20be65_19/version/0/width/120/height/75/quality/100
+8124	iConcerts	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/655bd3fbd7764b85b6c216cf352fa320_19/version/0/width/120/height/75/quality/100
+8368	UNIFE TV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/2b0d86675bb8428e91c55eada3982d01_19/version/0/width/120/height/75/quality/100
+8396	CNN	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/48a5c03f05264f969c71e56992a98847_19/version/1/width/120/height/75/quality/100
+8397	TVI Reality	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/8ae0590068384f8b85de367df743188e_19/version/1/width/120/height/75/quality/100
+8398	TLC	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd02f77c26cb4380a1da6a2fe90a938d_19/version/1/width/120/height/75/quality/100
+8399	V+ TVI	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/e2cbe6f3c7de4a77a37e4eb878b789f7_19/version/2/width/120/height/75/quality/100
+8424	RTP Madeira	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d6249f5eef264202874dfdd5de492a9e_19/version/1/width/120/height/75/quality/100
+8426	AMC Crime	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/d01e00520a5a4a2aaa1e1bf32f199dd5_19/version/1/width/120/height/75/quality/100
+8529	Dizi	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/87e626cfaddd45bba7703e3df96d2c38_19/version/0/width/120/height/75/quality/100
+8598	BenficaTV Multicam 1	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7ba831b33ef34380b3b5b462bbf355cf/version/0/width/120/height/75/quality/100
+8599	BenficaTV Multicam 2	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/6d713fb010f543a7a1e9848d6c791620/version/0/width/120/height/75/quality/100
+8600	BenficaTV Multicam 3	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/370959aa138a4805886fccabf38265e0/version/0/width/120/height/75/quality/100
+8601	BenficaTV Multicam 4	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b02508077c564f7883f8fc860f15b9c9/version/0/width/120/height/75/quality/100
+8606	AfroMusic 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b22774537d39440495b205b428e83a7f/version/0/width/120/height/75/quality/100
+8636	Panda Biggs	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/383f7e6f14ba48a0a69bde850dae7f50/version/0/width/120/height/75/quality/100
+8645	Nickelodeon	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4a5f17d29c7d4e74bea71046ffc50569/version/0/width/120/height/75/quality/100
+8646	MCM POP	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/610a1c775a4d4f89954924575c738b0e/version/0/width/120/height/75/quality/100
+8711	News Now 	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/7d1df4bc7fd948e3bbb57fefe3845ffb/version/0/width/120/height/75/quality/100
+8735	SIC Novelas	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/bd9e43272bc04420969e8e8ff0de8f8c/version/0/width/120/height/75/quality/100
+8743	Sport TV 7	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/079ac81d79f7490e844af481e5303d12/version/2/width/120/height/75/quality/100
+8775	HGTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/89768f1e6c1043279925acef9cadf5b8/version/0/width/120/height/75/quality/100
+8776	Disc ID	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/5aa45346d01440dabf96211bf118c28f/version/0/width/120/height/75/quality/100
+8781	BabyTV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/b422dbbb9fec4df5a07b6a383d906d56/version/0/width/120/height/75/quality/100
+8782	TCV	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/4280bb15af7b45068bbd15138531050b/version/0/width/120/height/75/quality/100
+8783	História	https://3038.images-vfp2.ott.kaltura.com/Service.svc/GetImage/p/3038/entry_id/f16aac14d6d54c8bb723397b3d743f08/version/0/width/120/height/75/quality/100


### PR DESCRIPTION
Thanks for taking the time to open a Pull Request (PR). Please take a moment to review our open/closed PRs above, in case a similar contribution has already been offered.

If you are opening a new Pull Request, please give it a descriptive title and fill out the blanks below, providing as much information as possible.

Pull Requests should be made against our master branch, and rebased if necessary.

What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
closes: https://github.com/XMLTV/xmltv/issues/235

Please explain what this PR does
--------------------------------
Refactors PT Vodafone grabber to work with the new available API.

Any other information?
----------------------
Due to contraints the available channels need to be on a separate file as there isn't any feasible way to fetch it programmatically without sharing personal details.

Where have you tested these changes?
------------------------------------
**Operating System:** OSX 12.7.6

**Perl Version:** v5.30.3
