### PR TITLE
Adds a hyphenated channel number as an additional display-name for each channel

### DIFF
--- a/grab/zz_sdjson/tv_grab_zz_sdjson
+++ b/grab/zz_sdjson/tv_grab_zz_sdjson
@@ -1008,6 +1008,25 @@ sub get_channel_number {
 	return undef;
 }
 
+sub get_channel_number_hyphen {
+	my ($map) = @_;
+
+	if($map->{'virtualChannel'}) {
+		return $map->{'virtualChannel'};
+	}
+	elsif($map->{'atscMajor'}) {
+		return "$map->{'atscMajor'}-$map->{'atscMinor'}";
+	}
+	elsif($map->{'channel'}) {
+		return $map->{'channel'};
+	}
+	elsif($map->{'frequencyHz'}) {
+		return $map->{'frequencyHz'};
+	}
+
+	return undef;
+}
+
 sub get_icon {
 	my ($url, $width, $height) = @_;
 	my %result;
@@ -1035,9 +1054,10 @@ sub write_channel {
 	# name, callsign and channel number. We follow that scheme here.
 	$ch{'id'} = sprintf($channel_id_format, $channel->{'stationID'});
 	$ch{'display-name'} = [
-		[ $channel->{'name'}       || 'unknown name'     ],
-		[ $channel->{'callsign'}   || 'unknown callsign' ],
-		[ get_channel_number($map) || 'unknown number'   ]
+		[ $channel->{'name'}              || 'unknown name'     ],
+		[ $channel->{'callsign'}          || 'unknown callsign' ],
+		[ get_channel_number($map)        || 'unknown number'   ],
+		[ get_channel_number_hyphen($map) || 'unknown number'   ]
 	];
 
 	my $logo = $channel->{'logo'};


### PR DESCRIPTION
Add a hyphen-separated channel number

Thanks for taking the time to open a Pull Request (PR). Please take a moment to review our open/closed PRs above, in case a similar contribution has already been offered.

If you are opening a new Pull Request, please give it a descriptive title and fill out the blanks below, providing as much information as possible.

Pull Requests should be made against our master branch, and rebased if necessary.

What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [X ] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
(If yes, please provide the issue number)
…
#250 

Please explain what this PR does
--------------------------------
…
It adds a new display-name tag for each channel that represents the channel number with a hyphen instead of the existing underscore.  If implemented, both variants will be included with each grab.

Any other information?
----------------------
(For example, has this change been discussed on the xmltv-devel mailing list?)
…

Where have you tested these changes?
------------------------------------
**Operating System:** …
Debian

**Perl Version:** …
