### PR TITLE
add deaf-signed subtitles element

### DIFF
--- a/grab/zz_sdjson_sqlite/tv_grab_zz_sdjson_sqlite
+++ b/grab/zz_sdjson_sqlite/tv_grab_zz_sdjson_sqlite
@@ -44,6 +44,7 @@
 #
 # Version history:
 #
+# 2025/01/16 - 1.138 - add deaf-signed subtitles element
 # 2024/08/02 - 1.137 - fix error handling in DB_open
 # 2024/01/27 - 1.136 - extend detail in schedules direct user-agent
 # 2024/01/27 - 1.135 - move from legacy cvs to modern versioning
@@ -232,7 +233,7 @@ my $RFC2838_COMPLIANT          = 1;            # RFC2838 compliant station ids, 
 my $SCRIPT_URL                 = 'https://github.com/garybuhrmaster/tv_grab_zz_sdjson_sqlite';
 my $SCRIPT_NAME                = basename("$0");
 my $SCRIPT_NAME_DIR            = dirname("$0");
-my $SCRIPT_VERSION             = '1.137';
+my $SCRIPT_VERSION             = '1.138';
 
 my $SCRIPT_DB_VERSION          = 2;            # Used for script/db updates (see DB_open)
 
@@ -2387,6 +2388,9 @@ $w->startTag('tv',
         # to collect the closed caption information for future
         # reporting.
         my $audioHasCC = 0;    # Need to carry forward
+        my $audioHasSubtitle = 0;
+        my $audioHasDVS = 0;
+        my $audioHasSigned = 0;
         if (defined($scheduleDetails->{'audioProperties'}))
           {
             # Ugly because dtd only allows one type, and source data
@@ -2400,6 +2404,9 @@ $w->startTag('tv',
                 $audioHasDolby = 1 if ($audioProperty eq 'Dolby');
                 $audioHasStereo = 1 if ($audioProperty eq 'stereo');
                 $audioHasCC = 1 if ($audioProperty eq 'cc');
+                $audioHasSubtitle = 1 if ($audioProperty eq 'subtitled');
+                $audioHasDVS = 1 if ($audioProperty eq 'dvs');
+                $audioHasSigned = 1 if ($audioProperty eq 'signed');
               }
             if ($audioHasDolbySurround || $audioHasDolby || $audioHasStereo)
               {
@@ -2467,6 +2474,8 @@ $w->startTag('tv',
 
         # Carried forward from audio eval to match DTD
         $w->emptyTag('subtitles', 'type' => 'teletext') if ($audioHasCC);
+        $w->emptyTag('subtitles', 'type' => 'onscreen') if ($audioHasSubtitle);
+        $w->emptyTag('subtitles', 'type' => 'deaf-signed') if ($audioHasSigned);
 
         # XMLTV ratings (and the system) are arbitrary values, and
         # have no implied priority or order.  However, for


### PR DESCRIPTION
add deaf-signed subtitles element to tv_grab_zz_sdjson_sqlite grabber

(cherry picked from commit 7b9803a6fbba51bb9814de1a4709b75334f64b78)

What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Please explain what this PR does
--------------------------------
Addresses repo issue 254 for the tv_grab_zz_sdjson_sqlite grabber


Where have you tested these changes?
------------------------------------
**Operating System:** Fedora 41

**Perl Version:** 5.40.0
