### PR TITLE
make sure xmltv.exe  tv_grab_zz_sdjson_sqlite agent string has the gr…

### DIFF
--- a/grab/zz_sdjson_sqlite/tv_grab_zz_sdjson_sqlite
+++ b/grab/zz_sdjson_sqlite/tv_grab_zz_sdjson_sqlite
@@ -232,8 +232,9 @@ my $RFC2838_COMPLIANT          = 1;            # RFC2838 compliant station ids, 
 
 my $SCRIPT_URL                 = 'https://github.com/garybuhrmaster/tv_grab_zz_sdjson_sqlite';
 my $SCRIPT_NAME                = basename("$0");
+   $SCRIPT_NAME                = "xmltv.exe:tv_grab_zz_sdjson_sqlite" if $SCRIPT_NAME eq 'xmltv.exe';
 my $SCRIPT_NAME_DIR            = dirname("$0");
-my $SCRIPT_VERSION             = '1.138';
+my $SCRIPT_VERSION             = '1.139';
 
 my $SCRIPT_DB_VERSION          = 2;            # Used for script/db updates (see DB_open)
 
@@ -259,7 +260,7 @@ my $SD_PROGRAM_RETRIES         = 3;            # Schedules Direct program reques
 
 my $JSON                       = JSON->new()->shrink(1)->utf8(1);
 
-my $SD = SchedulesDirect->new(UserAgent => "$SCRIPT_NAME ($^O) $SCRIPT_NAME/$SCRIPT_VERSION xmltv/$XMLTV::VERSION perl/" . sprintf("%vd", $^V) . " ");
+my $SD = SchedulesDirect->new(UserAgent => "$SCRIPT_NAME/$SCRIPT_VERSION ($^O) xmltv/$XMLTV::VERSION perl/" . sprintf("%vd", $^V) . " ");
 
 my $DBH;                                       # DataBase Handle
 


### PR DESCRIPTION
RobertK at SD reports this agent string at Schedules Direct

`xmltv.exe (MSWin32) xmltv.exe/1.138 xmltv/1.4.0_003 perl/5.32.1 libwww-perl/6.52`

Looking at the code, I see this
`my $SCRIPT_NAME                = basename("$0"); `

I recommend adding  to 
`$SCRIPT_NAME                = "xmltv.exe::tv_grab_zz_sdjson_sqlite" if $SCRIPT_NAME eq 'xmltv.exe';`

Also, the agent string seems to include the grabber name twice... 
`my $SD = SchedulesDirect->new(UserAgent => "$SCRIPT_NAME ($^O) $SCRIPT_NAME/$SCRIPT_VERSION xmltv/$XMLTV::VERSION`

Unless there is a reason, I reccomend
`my $SD = SchedulesDirect->new(UserAgent => "$SCRIPT_NAME/$SCRIPT_VERSION ($^O)  xmltv/$XMLTV::VERSION`

