### PR TITLE
fi: Include season/episode number in sub-title if available

### DIFF
--- a/grab/fi/fi/programme.pm
+++ b/grab/fi/fi/programme.pm
@@ -336,6 +336,9 @@ sub dump {
     $xmltv{'sub-title'} = $subtitle;
     debug(3, "XMLTV programme episode ($_->[1]): $_->[0]")
       foreach (@{ $xmltv{'sub-title'} });
+  } elsif (defined($season) && defined($episode)) {
+  	$xmltv{'sub-title'} = 'S' . $season . 'E' . $episode;
+    debug(3, "XMLTV programme subtitle: S$seasonE$episode");
   }
   if (defined($category) && length($category)) {
     $xmltv{category} = [[$category, $language]];


### PR DESCRIPTION
Thanks for taking the time to open a Pull Request (PR). Please take a moment to review our open/closed PRs above, in case a similar contribution has already been offered.

If you are opening a new Pull Request, please give it a descriptive title and fill out the blanks below, providing as much information as possible.

Pull Requests should be made against our master branch, and rebased if necessary.

What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
(If yes, please provide the issue number)
…

Please explain what this PR does
--------------------------------
To tv_grap_fi logic: Adds season and episode information to subtitle if it is missing and season and episode information is found
…

Any other information?
----------------------
This is made to improve Jellyfin series recognition 
…

Where have you tested these changes?
------------------------------------
**Operating System:** …
- NA
**Perl Version:** …
- NA