### PR TITLE
Fix syntax error in tv_grab_fi

### DIFF
--- a/grab/fi/fi/programme.pm
+++ b/grab/fi/fi/programme.pm
@@ -338,7 +338,7 @@ sub dump {
       foreach (@{ $xmltv{'sub-title'} });
   } elsif (defined($season) && defined($episode)) {
   	$xmltv{'sub-title'} = 'S' . $season . 'E' . $episode;
-    debug(3, "XMLTV programme subtitle: S$seasonE$episode");
+    debug(3, "XMLTV programme subtitle: S${season}E${episode}");
   }
   if (defined($category) && length($category)) {
     $xmltv{category} = [[$category, $language]];


### PR DESCRIPTION
What type of Pull Request is this?
----------------------------------
- [ ] adds new functionality
- [x] fixes/improves existing functionality

Does this PR close any currently open issues?
---------------------------------------------
No

Please explain what this PR does
--------------------------------
`xmltv/grab/fi/fi/programme.pm` has syntax error in variable call that prints:
```bash
Global symbol "$seasonE" requires explicit package name (did you forget to declare "my $seasonE"?) at /usr/bin/site_perl/tv_grab_fi line 705.
BEGIN not safe after errors--compilation aborted at /usr/bin/site_perl/tv_grab_fi line 818.
```
I added curly brackets to fix this

Any other information?
----------------------
No

Where have you tested these changes?
------------------------------------
**Operating System:** Cachy OS

**Perl Version:** v5.42.2
