### PR TITLE
tv_merge: write <display-name> before <url>/<icon> in channel output

### DIFF
--- a/filter/tv_merge
+++ b/filter/tv_merge
@@ -128,7 +128,7 @@ if ($debugmore) {
 my $tpp = XML::TreePP->new();
 $tpp->set( force_array => [ 'channel', 'programme' ] );  # force array ref for some fields
 $tpp->set( indent => 2 );
-$tpp->set( first_out => [ 'channel', 'programme', 'title', 'sub-title', 'desc', 'credits', 'date', 'category', 'keyword', 'language', 'orig-language', 'length', 'icon', 'url', 'country', 'episode-num', 'video', 'audio', 'previously-shown', 'premiere', 'last-chance', 'new', 'subtitles', 'rating', 'star-rating', 'review', 'image' ] );
+$tpp->set( first_out => [ 'channel', 'programme', 'title', 'sub-title', 'desc', 'credits', 'date', 'category', 'keyword', 'language', 'orig-language', 'length', 'display-name', 'icon', 'url', 'country', 'episode-num', 'video', 'audio', 'previously-shown', 'premiere', 'last-chance', 'new', 'subtitles', 'rating', 'star-rating', 'review', 'image' ] );
 
 my $xmltv = $tpp->parsefile( $input_file );
 if ($debugmore) { print Dumper($xmltv); }


### PR DESCRIPTION
### Problem

`tv_merge` writes `<channel>` elements with `<display-name>` **after** `<url>`/`<icon>`, even when both input files already have it in the correct order. This violates the XMLTV DTD, whose channel content model is `(display-name+, icon*, url*)`.

The consequence shows up in a `tv_merge | tv_sort` (or `tv_grep`) pipeline. The strict reader in `XMLTV.pm` consumes channel children in DTD order; when it reaches the out-of-order `display-name` it warns and skips it:

Seems to have been missed in this commit: https://github.com/XMLTV/xmltv/commit/4a7a18d548f0bcdb4a08c255c1c0d3f6ac472e1f

### Fix

Add `'display-name'` to `first_out`, immediately before `'icon'`, so channels serialize in DTD order as `display-name, icon, url`.
